### PR TITLE
Fix typo in overview-components.md /workflow/agent/s

### DIFF
--- a/content/guide/overview-components.md
+++ b/content/guide/overview-components.md
@@ -139,7 +139,7 @@ Cloudify's Management Worker, the Deployment Specific agents and the host agents
 Both the `deployment workflow agent` and the `deployment agent` drawn in the diagram are deployment specific. For every deployment created, two of these agents are spawned.
 
 * The `deployment workflow agent` executes deployment specific workflows.
-* The `deplomyent workflow` executes API calls to IaaS providers to create deployment resources or submits tasks to RabbitMQ so that host agents can execute them.
+* The `deplomyent agent` executes API calls to IaaS providers to create deployment resources or submits tasks to RabbitMQ so that host agents can execute them.
 
 Note that all agents (Management, Deployment Specific, Host) are actually the same physical entity (a virtualenv with Python modules - Cloudify plugins installed in them).
 


### PR DESCRIPTION
Fix small typo in docs. 
Seems like author meant  "deployment agent" instead of "deployment workflow"