### PR TITLE
--installvirtualenv changed to --install-virtualenv per warning

### DIFF
--- a/content/installation/from-script.md
+++ b/content/installation/from-script.md
@@ -39,7 +39,7 @@ Run the following command in order to create new virtualenv (`my_virtualenv`) an
 install Cloudify in it:
 
 {{< gsHighlight  bash  >}}
-$ python get-cloudify.py -e my_virtualenv --installvirtualenv
+$ python get-cloudify.py -e my_virtualenv --install-virtualenv
 ...
 
 20:21:40 [INFO] [get-cloudify.py] virtualenv is already installed in the path.


### PR DESCRIPTION
[WARNING] [get-cloudify.py] --installvirtualenv is deprecated. Use --install-virtualenv. --installvirtualenv will be removed in a future release.