### PR TITLE
Update getting-started.md

### DIFF
--- a/content/intro/getting-started.md
+++ b/content/intro/getting-started.md
@@ -26,7 +26,7 @@ Once downloaded, extract the file to a directory and cd into it.
 Now let's prepare the environment for our application:
 
 {{< gsHighlight  bash >}}
-$ cfy local init --blueprint-path blueprint.yaml --inputs '{"webserver_port": "8000", "host_ip":"localhost"}'
+$ cfy local init --blueprint-path blueprint.yaml
 ...
 
 Initiated blueprint.yaml


### PR DESCRIPTION
The use of --inputs '{"webserver_port": "8000", "host_ip":"localhost"}'  fails with the following errors on RHEL 6.7 Linux based host running bash:

usage: cfy [-h] [--version]  ...
cfy: error: unrecognized arguments: "8000", "host_ip":"localhost"}

suggest removal of --inputs option given the blueprint defaults to these settings, show "--inputs" example elsewhere in docs.
