### PR TITLE
Fix a mistaken word for title in from-packages.md

### DIFF
--- a/content/installation/from-packages.md
+++ b/content/installation/from-packages.md
@@ -1,6 +1,6 @@
 ---
 layout: bt_wiki
-title: Installing using packages for commmon OS distributions
+title: Installing using packages for common OS distributions
 category: Installation
 draft: false
 weight: 200


### PR DESCRIPTION
The title contains a mistaken word in from-packages.md.

AS IS 
Installing using packages for commmon OS distributions
TO BE
Installing using packages for common OS distributions

Please check it and Thanks!