### PR TITLE
Fix a link for wagon in plugins.md

### DIFF
--- a/content/cli/plugins.md
+++ b/content/cli/plugins.md
@@ -11,7 +11,7 @@ The `cfy plugins` command is used to manage plugins stored on a Cloudify manager
 
 You can use the command to upload, download, delete and list plugins and also to get information on a specific plugin.
 
-A Cloudify plugin is an archive created by [wagon]({{< relref "http://github.com/cloudify-cosmo/wagon" >}}).
+A Cloudify plugin is an archive created by [wagon](https://github.com/cloudify-cosmo/wagon).
 
 See [plugins]({{< relref "plugins/overview.md" >}}) for more information.
 


### PR DESCRIPTION
It can not access the wagon via the link in plugins.md and fix the link to visit the wagon in GitHub directly.

AS IS
({{< relref "http://github.com/cloudify-cosmo/wagon" >}})
TO BE
(https://github.com/cloudify-cosmo/wagon)

Please check it and Thanks!