### PR TITLE
Add a required flag in cli/recover.md

### DIFF
--- a/content/cli/recover.md
+++ b/content/cli/recover.md
@@ -14,7 +14,7 @@ weight: 170
 
 The `cfy recover` command is used to recover a manager to a previous state using a manager snapshot.
 
-Usage: `cfy recover [options] -s SNAPSHOT_PATH`
+Usage: `cfy recover [options] -s SNAPSHOT_PATH -f`
 
 Recover the manager using the provided snapshot.
 


### PR DESCRIPTION
Add a required flag for the cfy recover command  in cli/recover.md. According to the required flags, we can get the massage that  " -f, --force - Force recovery. This flag is mandatory" in the required flags.

AS IS 
cfy recover [options] -s SNAPSHOT_PATH
TO BE
cfy recover [options] -s SNAPSHOT_PATH -f

Please check it and thanks!