### PR TITLE
Fix the description for the cfy status command

### DIFF
--- a/content/cli/status.md
+++ b/content/cli/status.md
@@ -9,7 +9,7 @@ weight: 210
 
 The `cfy status` command is used to print out the status of a running manager.
 
-To use the command you must `cfy use -t MANAGEMENT_IP` first.
+To use the command you should `cfy use -t MANAGEMENT_IP` or `cfy bootstrap` first.  See [cfy bootstrap]({{< relref "cli/bootstrap.md" >}}) for more information.
 
 
 Usage: `cfy status`


### PR DESCRIPTION
Fix the description for the cfy status command in cli/status.md.

AS IS
To use the command you must 'cfy use -t MANAGEMENT_IP' first.
TO BE
To use the command you should `cfy use -t MANAGEMENT_IP` or `cfy bootstrap` first.  See [cfy bootstrap]({{< relref "cli/bootstrap.md" >}}) for more information.

Please check it and thanks!