### PR TITLE
Add descriptions of inputs file using the Mananger

### DIFF
--- a/content/manager/getting-started.md
+++ b/content/manager/getting-started.md
@@ -117,7 +117,8 @@ This blueprint defines some input parameters:
 
 ![Nodecellar Inputs]({{< img "guide/quickstart/nodecellar_singlehost_inputs.png" >}})
 
-The inputs values are located at ~/cloudify/blueprints/inputs/nodecellar-singlehost.yaml.
+You can find singlehost.yaml.template, which is a blueprint inputs file, in cloudify-nodecellar-example/inputs. Copy it and modify its name to nodecellar-singlehost.yaml
+The inputs values are located at ~/cloudify/blueprints/cloudify-nodecellar-example/inputs/nodecellar-singlehost.yaml.
 
 These are the values relevant for our example:
 


### PR DESCRIPTION
Add descriptions for editing inputs file when using the Manager and  modify the path of inputs file in the cfy blueprints command. It can be helpful to understand clearly using the inputs file.

Please check them and  merge them to 3.5.0-build,3.4.0-build and 3.4.1-build 
Thanks!,
