### PR TITLE
Fix a link for prerequisites in bootstrapping.md

### DIFF
--- a/content/manager/bootstrapping.md
+++ b/content/manager/bootstrapping.md
@@ -40,7 +40,7 @@ This will create a folder in the current directory named `.cloudify`.
 # Prepare the Bootstrap Configuration
 
 {{% gsNote title="Note" %}}
-Please verify the [prerequisites]({{< relref "manager/bootstrapping.md" >}}) before bootstrapping.
+Please verify the [prerequisites]({{< relref "manager/prerequisites.md" >}}) before bootstrapping.
 {{% /gsNote %}}
 
 If you installed Cloudify using one of the premade packages, the manager blueprints should already be available to you.


### PR DESCRIPTION
Fix a link for prerequisites in bootstrapping.md which can not access the prerequisites page.

AS IS
prerequisites ({{< relref "manager/bootstrapping.md" >}}) 
TO BE
prerequisites ({{< relref "manager/prerequisites.md" >}}) 

Please check it and merge it to 3.5.0-build and 3.4.1-build 
Thanks!