### PR TITLE
Fix a link for deploy in upload-blueprint.md

### DIFF
--- a/content/manager/upload-blueprint.md
+++ b/content/manager/upload-blueprint.md
@@ -116,4 +116,4 @@ In our case, we have the following nodes:
 
 # What's Next
 
-You should now have a Blueprint ready for you to [deploy]({{< relref "manager/bootstrapping.md" >}}).
+You should now have a Blueprint ready for you to [deploy]({{< relref "manager/create-deployment.md" >}}).


### PR DESCRIPTION
Fix a link for deploy in upload-blueprint.md which can not access the create-deploymentpage.

AS IS
deploy ({{< relref "manager/bootstrapping.md" >}})
TO BE
deploy ({{< relref "manager/create-deployment.md" >}})

Please check it and merge it to 3.5.0-build and 3.4.1-build 
Thanks!