### PR TITLE
CFY-6712. Update API docs link for 4.0.0

### DIFF
--- a/content/apis/rest-service.html
+++ b/content/apis/rest-service.html
@@ -9,6 +9,6 @@ weight: 600
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <meta http-equiv="refresh" content="0;url=http://docs.getcloudify.org/api/"/>
+    <meta http-equiv="refresh" content="0;url=http://docs.getcloudify.org/api/v3"/>
   </head>
 </html>


### PR DESCRIPTION
In this PR, the API docs link is updated to:
http://docs.getcloudify.org/api/v3