### PR TITLE
Fix RabbitMQ port

### DIFF
--- a/content/installation/bootstrapping.md
+++ b/content/installation/bootstrapping.md
@@ -44,7 +44,7 @@ Cloudify Manager listens on the following ports:
  443    | REST API and UI. This port must be accessible when SSL is enabled.
  8101   | REST API. This port is used for internal access and therefore must only be accessible from `Agent VMs`.
  22     | During bootstrap, components are installed and configured via SSH. It is also used during recovery of cloudify Manager.
- 5672   | RabbitMQ. This port must be accessible from agent VMs.
+ 5671   | RabbitMQ. This port must be accessible from agent VMs.
  53229  | File server. This port must be accessible from agent VMs.
  53333  | Internal REST communications. This port must be accessible from agent VMs.
 


### PR DESCRIPTION
It's 5671 starting 4.x (and SSL-protected)