### PR TITLE
minor fixes to 4.1 version

### DIFF
--- a/content/installation/from-packages.md
+++ b/content/installation/from-packages.md
@@ -14,10 +14,10 @@ the installation process.
 
 ## Linux
 
-1. [Download the installer](http://getcloudify.org/downloads/get_cloudify_3x.html) that is appropriate to your operating system and installation preference, either user interface or terminal-based.
+1. [Download the installer](http://cloudify.co/downloads/get_cloudify.html) that is appropriate to your operating system and installation preference, either user interface or terminal-based.
 2. Select one of the following installation options:   
    * To install from a user interface, double-click the UI installation file you downloaded.<br>
-   * To install using terminal commands, run the command appropriate to your operating system.     <br>
+   * To install using terminal commands, run the command appropriate to your operating system.<br>
 
      
     #### Centos/RHEL
@@ -58,6 +58,6 @@ The Python setup wizard, will prompt you to select whether to install pip. Regar
 
 ##### Install on Windows
 
-1. [Download the installer](http://getcloudify.org/downloads/get_cloudify_3x.html) appropriate to your Windows environment.
+1. [Download the installer](http://cloudify.co/downloads/get_cloudify.html) appropriate to your Windows environment.
 2. Run the installer, following the prompts in the installation.
 

--- a/content/installation/uninstall-cloudify-cli.md
+++ b/content/installation/uninstall-cloudify-cli.md
@@ -7,10 +7,17 @@ weight: 500
 
 ---
 
- In the event that you need to uninstall Cloudify, use the following procedure that is relevant to your platform. <br>
- Uninstalling the package does not remove Python, pip or Virtualenv.
+In the event that you need to uninstall Cloudify, use the following procedures.
 
- You can also remove an instance of Cloudify Manager using the [`teardown` command]({{< relref "cli/teardown.md" >}}) in the CLI.
+## Removing Cloudify Manager from the Virtual Machine
+
+You remove an instance of Cloudify Manager from a VM using the [`teardown` command]({{< relref "cli/teardown.md" >}}) in the CLI. This process removes Cloudify Manager without deleting the VM.
+
+
+## Removing the Cloudify Command Line Interface
+
+After tearing down Cloudify Manager, you can remove the CLI. Use the process below that is relevant to your platform. <br>
+Uninstalling the package does not remove Python, pip or Virtualenv.
 
 ### Uninstall Cloudify from CentOS/RHEL
 
@@ -31,4 +38,7 @@ weight: 500
 
 1. Open **Programs** from the **Control Panel**.
 2. Select **Cloudify CLI**, then click **Uninstall**.
+
+
+
 

--- a/content/installation/upgrade_4-0-0.md
+++ b/content/installation/upgrade_4-0-0.md
@@ -10,7 +10,7 @@ weight: 350
 This topic describes how to upgrade Cloudify Manager.
 
 {{% gsTip title="Version Relevance" %}}
-You can use this process to replace an existing Cloudify Manager 4.0.0 with a new one of the same version.
+You can use this process to replace an existing Cloudify Manager 4.x with a new one of version 4.0, or higher.
 {{% /gsTip %}}
 
 Upgrading Cloudify Manager entails tearing down the existing Manager and installing a new one on the same virtual machine. You can also restore data and agents' certificates from your existing instance to your new instance. 

--- a/content/intro/cloudify-manager.md
+++ b/content/intro/cloudify-manager.md
@@ -31,4 +31,4 @@ In addition, Cloudify Manager:
 
 Although you can use Cloudify to provision resources directly from the CLI, use Cloudify Manager to manage production-level applications.
 
-For more information about Cloudify Manager, see the [Cloudify Manager]({{< relref "manager/getting-started.md" >}}) section.
+For more information about Cloudify Manager, see the Cloudify Manager section later in this user's guide.

--- a/content/intro/doc-info.md
+++ b/content/intro/doc-info.md
@@ -14,7 +14,7 @@ The documentation center has been designed to assist you to easily navigate to t
 **[Cloudify API References](http://docs.getcloudify.org/api/):**						Guides related to the Python and REST APIs<br><br>
 **[Cloudify Plugins](http://cloudify-plugins-common.readthedocs.io/en/3.3/):**								Documentation for supported plugins and customizing plugins<br><br>
 **[Cloudify Videos, Tutorials, Blogs & More](http://getcloudify.org/cloudifysourcetv.html):**		Links to Cloudify demo and tutorial videos to blogs and white papers, and to Cloudify Academy<br><br>
-**Cloudify Release Notes:** Release notes are accessible from the main Cloudify website. Select the release notes that are relevant to your installation. Either **[Cloudify Manager 4.1 release notes for Premium customers](http://getcloudify.org/downloads/releasenotes/release-notes-4_1.html)** or **[Cloudify Manager 4.0 Community Edition release notes](http://getcloudify.org/downloads/releasenotes/release-notes-4_1.html)**.
+**Cloudify Release Notes:** Release notes are accessible from the main Cloudify website. Select the release notes that are relevant to your installation. Either **[Cloudify Manager 4.1 release notes for Premium customers](http://getcloudify.org/downloads/releasenotes/release-notes-4_1.html)** or **[Cloudify Manager 4.1 Community Edition release notes](http://getcloudify.org/downloads/releasenotes/release-notes-4_1.html)**.
 
 
 A table of contents for the entire Documentation Center appears on the left of all pages in the site. You can use the table of contents to drill down into a document to the content that you require.

--- a/content/intro/doc-info.md
+++ b/content/intro/doc-info.md
@@ -14,7 +14,7 @@ The documentation center has been designed to assist you to easily navigate to t
 **[Cloudify API References](http://docs.getcloudify.org/api/):**						Guides related to the Python and REST APIs<br><br>
 **[Cloudify Plugins](http://cloudify-plugins-common.readthedocs.io/en/3.3/):**								Documentation for supported plugins and customizing plugins<br><br>
 **[Cloudify Videos, Tutorials, Blogs & More](http://getcloudify.org/cloudifysourcetv.html):**		Links to Cloudify demo and tutorial videos to blogs and white papers, and to Cloudify Academy<br><br>
-**Cloudify Release Notes:** Release notes are accessible from the main Cloudify website. Select the release notes that are relevant to your installation. Either **[Cloudify Manager 4.0 release notes for Premium customers](http://getcloudify.org/downloads/releasenotes/release-notes-4_0.html)** or **[Cloudify Manager 4.0 Community Edition release notes](http://getcloudify.org/downloads/releasenotes/release-notes-4_0.html)**.
+**Cloudify Release Notes:** Release notes are accessible from the main Cloudify website. Select the release notes that are relevant to your installation. Either **[Cloudify Manager 4.1 release notes for Premium customers](http://getcloudify.org/downloads/releasenotes/release-notes-4_1.html)** or **[Cloudify Manager 4.0 Community Edition release notes](http://getcloudify.org/downloads/releasenotes/release-notes-4_1.html)**.
 
 
 A table of contents for the entire Documentation Center appears on the left of all pages in the site. You can use the table of contents to drill down into a document to the content that you require.

--- a/content/intro/evaluating-cloudify.md
+++ b/content/intro/evaluating-cloudify.md
@@ -96,7 +96,7 @@ To confirm the application is working, attempt to access it locally, or remotely
      ```</body>```<br>
      ```</html>[root@centos7 simple-python-webserver-blueprint]#```
 
-   * To test the application remotely, open a browser on a server that has access to the Linux server and browse to **http://localhost:8080**, as shown in the following screen capture.     
+   * To test the application remotely, open a browser on a server that has access to the Linux server and browse to http://localhost:8080, as shown in the following screen capture.     
      
      ![Access application remotely]({{< img "intro/evaluation-simple-6.png" >}})
 


### PR DESCRIPTION
Primarily updates to version numbers in the intro pages. Please take a look at uninstalling Cloudify, where the teardown section has been added, to ensure that it is accurate.