### PR TITLE
(temporarily) remove secrets section from GCP page

### DIFF
--- a/content/plugins/gcp.md
+++ b/content/plugins/gcp.md
@@ -23,24 +23,6 @@ Be aware that some services and resources vary in availability between regions a
 
 The GCP plugin uses the official [Google API Python Client](https://github.com/google/google-api-python-client).
 
-# Configuration
-
-## Accessing Secrets
-
- It is recommended that you store your credentials as [secrets]({{< relref "manager/using-secrets.md" >}}). You can do this using the [CLI]({{< relref "cli/secrets.md" >}}).
- Secrets can then be accessed inside your blueprints, as follows:
-
- {{< gsHighlight  yaml  >}}
- external_network:
-    type: cloudify.gcp.nodes.Network
-    properties:
-      gcp_config:  
-        username: { get_secret: keystone_username }
-        password: { get_secret: keystone_password }
-        tenant_name: { get_secret: keystone_tenant_name }
-        auth_url: { get_secret: keystone_url }
-        region: { get_secret: region }
- {{< /gsHighlight >}}   
 
 # Terminology
 


### PR DESCRIPTION
Should be added with updated keys once https://cloudifysource.atlassian.net/browse/GCP-41 is done