### PR TITLE
Adding skip-plugins-validations

### DIFF
--- a/content/blueprints/spec-plugins.md
+++ b/content/blueprints/spec-plugins.md
@@ -54,6 +54,7 @@ If no managed plugin is found and `source` is not defined, plugin installation f
 
 * A URL to an archive of the plugin to be installed.
 * The name of a directory containing the plugin, which is expected to be inside the blueprint's `plugins` directory.
+* The `source` method should only be used when developing plugins and the `skip_plugins_validation` flag should be passed at deployment time.
 
 ## Managed Plugins
 

--- a/content/blueprints/spec-plugins.md
+++ b/content/blueprints/spec-plugins.md
@@ -54,7 +54,7 @@ If no managed plugin is found and `source` is not defined, plugin installation f
 
 * A URL to an archive of the plugin to be installed.
 * The name of a directory containing the plugin, which is expected to be inside the blueprint's `plugins` directory.
-* The `source` method should only be used when developing plugins and the `skip_plugins_validation` flag should be passed at deployment time.
+* The `source` method should only be used when developing plugins and the `skip-plugins-validation` flag should be passed at deployment time.
 
 ## Managed Plugins
 

--- a/content/cli/deployments.md
+++ b/content/cli/deployments.md
@@ -51,6 +51,7 @@ Create a deployment on the Manager
                         Inputs for the deployment (Can be provided as wildcard-based paths (*.yaml, etc..) to YAML files, a JSON
                         string or as "key1=value1;key2=value2"). This argument
                         can be used multiple times.
+ * `--skip-plugins-validation` - A boolean flag that specifies whether to validate if the required deployment plugins exist on the Manager. [Default: `false`]
 
 
 &nbsp;

--- a/content/cli/deployments.md
+++ b/content/cli/deployments.md
@@ -81,19 +81,19 @@ Update a specified deployment according to the specified blueprint.
 *  `-p, --blueprint-path PATH` - 
                         This is a mandatory flag.
 
- #### Optional flags 
+#### Optional flags 
 
  *  `-i, --inputs TEXT` -
                         Inputs for the deployment (Can be provided as
-                        wildcard-based paths (*.yaml, /my_inputs/,
+                        wildcard-based paths (`*.yaml`, `/my_inputs/`,
                         etc..) to YAML files, a JSON string or as
-                        key1=value1;key2=value2). This argument can
+                        `key1=value1;key2=value2`). This argument can
                         be used multiple times.
 *  `-n, --blueprint-filename TEXT` -
                         The name of the archive's main blueprint file.
-                        (default: blueprint.yaml). Only relevant if uploading an archive.
+                        (default: `blueprint.yaml`). Only relevant if uploading an archive.
 *  `-w, --workflow-id TEXT` - 
-                        The workflow to execute [default: update]
+                        The workflow to execute [default: `update`]
 *  `--skip-install` -   Skip install lifecycle operations.
 
 *  `--skip-uninstall` - Skip uninstall lifecycle operations.
@@ -101,8 +101,8 @@ Update a specified deployment according to the specified blueprint.
 *  `-f, --force` -      Force an update to run, in the event that a previous
                         update on this deployment has failed to
                         complete successfully.
-*  `--include-logs / --no-logs` - Include logs in returned events [default: True]
-*  `--json-output` -           Output events in a consumable JSON format
+*  `--include-logs / --no-logs` - Include logs in returned events [default: `True`]
+*  `--json-output` -   Output events in a consumable JSON format
 *  `-t, --tenant-name TEXT` - 
                         The name of the tenant of the deployment. If unspecified, the current tenant is
                                  used.
@@ -246,7 +246,9 @@ Lists all outputs for a deployment. Note that not every deployment has outputs a
 
 `DEPLOYMENT_ID` -       The ID of the deployment for which you want to list outputs.
 
+
 #### Optional flags
+
 
 *  `-t, --tenant-name TEXT` -   The name of the tenant for which you want to list outputs. If
                            unspecified, the current tenant is used.

--- a/content/cli/deployments.md
+++ b/content/cli/deployments.md
@@ -76,16 +76,14 @@ Update a specified deployment according to the specified blueprint.
 `DEPLOYMENT_ID` -       is the deployment's ID to update.
 
 
-*  `-p, --blueprint-path PATH` - 
-                        Is a mandatory flag.
-
 #### Mandatory flags
 
 *  `-p, --blueprint-path PATH` - 
                         This is a mandatory flag.
 
- #### Optional flags                       
-*  `-i, --inputs TEXT` -
+ #### Optional flags 
+
+ *  `-i, --inputs TEXT` -
                         Inputs for the deployment (Can be provided as
                         wildcard-based paths (*.yaml, /my_inputs/,
                         etc..) to YAML files, a JSON string or as
@@ -103,8 +101,7 @@ Update a specified deployment according to the specified blueprint.
 *  `-f, --force` -      Force an update to run, in the event that a previous
                         update on this deployment has failed to
                         complete successfully.
-*  `--include-logs / --no-logs` -     
-                        Include logs in returned events [default: True]
+*  `--include-logs / --no-logs` - Include logs in returned events [default: True]
 *  `--json-output` -           Output events in a consumable JSON format
 *  `-t, --tenant-name TEXT` - 
                         The name of the tenant of the deployment. If unspecified, the current tenant is

--- a/content/cli/deployments.md
+++ b/content/cli/deployments.md
@@ -86,7 +86,7 @@ Update a specified deployment according to the specified blueprint.
  *  `-i, --inputs TEXT` -
                         Inputs for the deployment (Can be provided as
                         wildcard-based paths (`*.yaml`, `/my_inputs/`,
-                        etc..) to YAML files, a JSON string or as
+                        etc.) to YAML files, a JSON string or as
                         `key1=value1;key2=value2`). This argument can
                         be used multiple times.
 *  `-n, --blueprint-filename TEXT` -

--- a/content/cli/deployments.md
+++ b/content/cli/deployments.md
@@ -47,11 +47,8 @@ Create a deployment on the Manager
 
 *  `-d, --deployment-id=DEPLOYMENT_ID` -
                         A unique ID for the deployment
-*  `-i, --inputs=INPUTS` -
-                        Inputs for the deployment (Can be provided as wildcard-based paths (*.yaml, etc..) to YAML files, a JSON
-                        string or as "key1=value1;key2=value2"). This argument
-                        can be used multiple times.
- * `--skip-plugins-validation` - A boolean flag that specifies whether to validate if the required deployment plugins exist on the Manager. [Default: `false`]
+*  `-i, --inputs=INPUTS` - Inputs for the deployment (Can be provided as wildcard-based paths (`.yaml`, etc..) to YAML files, a JSON          string or as `key1=value1;key2=value2`). This argument can be used multiple times.
+* `--skip-plugins-validation` - A boolean flag that specifies whether to validate if the required deployment plugins exist on the Manager. [Default: `false`]
 
 
 &nbsp;

--- a/content/manager/create-deployment.md
+++ b/content/manager/create-deployment.md
@@ -43,7 +43,7 @@ After initialization is complete, you can start using the deployment and executi
 
 #### Example: Creating a Deployment
 
-This example shows how a deployment can be created for a blueprint, using the command line.
+This example shows how a deployment can be created for a blueprint, using the command line. For more information about creating deployments using the command line, [click here]({{< relref "cli/deployments.md" >}}).
 
 First create an inputs file (in a similar way to the Manager blueprint's inputs dialog):
 


### PR DESCRIPTION
I have added this in the **blueprints > plugins** and **cli > deployments** pages, and have added a pointer from the **manager > creating a deployment** page to the CLI page. 

After this is approved and merged into the 4.1 documentation, I will add it to the 4.2 branch.

**Is this also relevant for 4.0?