### PR TITLE
Docathon - [UI] Open Source, Custom Widgets Permissions

### DIFF
--- a/content/manager_webui/custom-widgets.md
+++ b/content/manager_webui/custom-widgets.md
@@ -62,7 +62,8 @@ Option                 | Type    | Default | Description
 `isREact`              | boolean | `false` | Set as `true` when writing a React widget.
 `fetchUrl`             | string/object | - | If `fetchUrl` exists, the data from the URL is fetched by the application and passed to the render and postRender methods. To fetch multiple URLs, you must pass an object where the key is a name you select for this data, and the value is the URL. It is important to note that the render is called once before the data is fetched (to enable information about loading or partial data can be displayed) and once after the data is fetched.
 `initialConfiguration` | array   | -       | A list of widget configuration options. The options are displayed when a user clicks the **`Configure`** button on the widget in edit mode. It can also be accessed in the widget, to determine the current selected configuration.
-`pageSize`             | integer | -       | The initital page size for widgets that support pagination.
+`pageSize`             | integer | -       | The initial page size for widgets that support pagination.
+`permission`           | string  | -       | This property specifies which user may later access and view this widget. It may take one of the following three values `widget_custom_admin`, `widget_custom_sys_admin`, `widget_custom_all`. Mandatory.
 
 ### Widget Functions
 The following functions are available for widgets.

--- a/content/manager_webui/overview.md
+++ b/content/manager_webui/overview.md
@@ -40,14 +40,14 @@ In addition to the default widgets, you can create your own and add them to the 
 
 ## Community Version
 As of Release 4.2, Cloudify Web UI is also available in `Community` version (Open Source). This edition keeps all the features of the `Premium` with the exception of the following:
-- No tenant management
+- No user, user group or tenant management
 - No composer access
 - Custom initial template
 
-### Tenant Management
-For Cloudify Community Edition users, a single tenant with a single user is created during installation. When you log into Cloudify Manager, the built-in credentials are used.
+### User/tenant Management
+For Cloudify Community Edition users, a single tenant with a single user is created during installation. When you log into Cloudify Manager, the built-in credentials are used. Features allowing for user, tenant and user group managing are disabled.
 
-Multiple tenant management is available in the `Premium` version. This feature allows you to define multiple roles and tenants and build complex user access hierarchies atop those those two functions. You can read more about tenants [here]({{< relref "manager_webui/tenant-management-page.md" >}}). 
+User and tenant management is available in the Cloudify `Premium` version. These features allows you to define multiple users, roles and tenants to build complex access hierarchies atop of those those features. You can read more about users [here]({{< relref "cli/users.md" >}}) and tenants [here]({{< relref "manager_webui/tenant-management-page.md" >}}).
 
 ### Composer Access
 Composer is not available in the Community version, however you have full access to the Cloudify CLI tools to manage your blueprints. Composer, which is available in the `Premium` version provides quick and easy means for rapid blueprint development. You can read more about Composer [here]({{< relref "composer/overview.md" >}}).

--- a/content/manager_webui/overview.md
+++ b/content/manager_webui/overview.md
@@ -40,6 +40,7 @@ In addition to the default widgets, you can create your own and add them to the 
 
 ## Community Version
 As of Release 4.2, Cloudify Web UI is also available in `Community` version (Open Source). This edition keeps all the features of the `Premium` with the exception of the following:
+
 - No user, user group or tenant management
 - No composer access
 - Custom initial template
@@ -61,5 +62,5 @@ When a user first logs in into Cloudify Web UI, he is presented with the default
 - Deployments
 - System Resources
 
- Currently the only difference between `Community` and `Premium` editions is the absence of `tenant management` page in `Community`.
+The only difference in this respect is the absence of `tenant management` page in the `Community` version.
 

--- a/content/manager_webui/overview.md
+++ b/content/manager_webui/overview.md
@@ -15,7 +15,7 @@ The Cloudify Web interface is provided to Premium customers and requires a Cloud
 
 {{% gsNote title="Note" %}}
 The view that you see depends on whether you log in as `admin` or `user`. Certain dashboard views, such as for snapshots, are only available to `admin` users.<br>
-This document describes all the pages and functionality that are avaiable to `admin` users.
+This document describes all the pages and functionality that are available to `admin` users.
 {{% /gsNote %}}
 
 Cloudify Manager supports user management, so users must log in with user credentials. User credentials can be defined in Cloudify from an LDAP system, whether the LDAP system is integrated with Cloudify or derived from an external LDAP user management system.
@@ -38,5 +38,28 @@ To enter Edit mode, click the dropdown arrow next to your user name and select *
 ### Custom Widgets
 In addition to the default widgets, you can create your own and add them to the widgets catalog. 
 
+## Community Version
+As of Release 4.2, Cloudify Web UI is also available in `Community` version (Open Source). This edition keeps all the features of the `Premium` with the exception of the following:
+- No tenant management
+- No composer access
+- Custom initial template
 
+### Tenant Management
+For Cloudify Community Edition users, a single tenant with a single user is created during installation. When you log into Cloudify Manager, the built-in credentials are used.
+
+Multiple tenant management is available in the `Premium` version. This feature allows you to define multiple roles and tenants and build complex user access hierarchies atop those those two functions. You can read more about tenants [here]({{< relref "manager_webui/tenant-management-page.md" >}}). 
+
+### Composer Access
+Composer is not available in the Community version, however you have full access to the Cloudify CLI tools to manage your blueprints. Composer, which is available in the `Premium` version provides quick and easy means for rapid blueprint development. You can read more about Composer [here]({{< relref "composer/overview.md" >}}).
+
+### Custom initial template
+When a user first logs in into Cloudify Web UI, he is presented with the default pages layout. Pages currently available by default in `Community` version are as follows:
+
+- Dashboard
+- Blueprint Catalog
+- Local Blueprint Catalog
+- Deployments
+- System Resources
+
+ Currently the only difference between `Community` and `Premium` editions is the absence of `tenant management` page in `Community`.
 


### PR DESCRIPTION
Updated docs to include information about "permissions" field in Widgets definition along with a new paragraph discussing the 'Community' edition of Cloudify Web UI

You can preview the changes here:
**Custom Widgets**
http://stage-docs.getcloudify.org/docathon-UI-opensource-custom-widgets/manager_webui/custom-widgets/
**Open Source**
http://stage-docs.getcloudify.org/docathon-UI-opensource-custom-widgets/manager_webui/overview/