### PR TITLE
add `pip install --upgrade pip` to "offline" installation instructions

### DIFF
--- a/content/installation/bootstrapping.md
+++ b/content/installation/bootstrapping.md
@@ -326,6 +326,7 @@ Run the following command to prepare the python virtual environment.
 {{< gsHighlight  bash  >}}
 virtualenv ~/cloudify/env
 source ~/cloudify/env/bin/activate
+pip install --upgrade pip
 pip install https://github.com/cloudify-cosmo/cloudify-rest-client/archive/4.1.zip
 pip install https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/4.1.zip
 pip install https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/4.1.zip


### PR DESCRIPTION
`python-virtualenv` package on CentOS 7 installs pip 1.4.1 which is positively ancient, and can't cope with some of the wheels in our wagons.