### PR TITLE
Upload blueprint command

### DIFF
--- a/content/manager/upload-blueprint.md
+++ b/content/manager/upload-blueprint.md
@@ -16,7 +16,7 @@ From the Cloudify command-line interface, you can upload your blueprint to Cloud
 
 The following is an example of `upload`:
 {{< gsHighlight  bash >}}
-$ cfy blueprints upload -b BLUEPRINT_ID -p BLUEPRINT_FILE_LOCATION
+$ cfy blueprints upload -b BLUEPRINT_ID -n BLUEPRINT_FILE_LOCATION URL_TO_BLUEPRINT_ARCHIVE
 ...
 
 ...
@@ -49,28 +49,28 @@ If you have downloaded cloudify-nodecellar-example from github and want to use t
 
   {{% gsTabContent "OpenStack" %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -p openstack-blueprint.yaml
+  cfy blueprints upload -b nodecellar -n openstack-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 
   **SoftLayer**
   {{% gsTabContent "SoftLayer" %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -p softlayer-blueprint.yaml
+  cfy blueprints upload -b nodecellar -n softlayer-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 
   **Amazon Web Service**
   {{% gsTabContent "AWS EC2" %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -p aws-ec2-blueprint.yaml
+  cfy blueprints upload -b nodecellar -n aws-ec2-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 
   **vCloud**
   {{% gsTabContent "vCloud " %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -p vcloud-blueprint.yaml
+  cfy blueprints upload -b nodecellar -n vcloud-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 

--- a/content/manager/upload-blueprint.md
+++ b/content/manager/upload-blueprint.md
@@ -50,28 +50,28 @@ If you have downloaded cloudify-nodecellar-example from github and want to use t
 
   {{% gsTabContent "OpenStack" %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -n openstack-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
+  cfy blueprints upload -b nodecellar -n openstack-blueprint.yaml PATH_OR_URL_OF_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 
   **SoftLayer**
   {{% gsTabContent "SoftLayer" %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -n softlayer-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
+  cfy blueprints upload -b nodecellar -n softlayer-blueprint.yaml PATH_OR_URL_OF_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 
   **Amazon Web Service**
   {{% gsTabContent "AWS EC2" %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -n aws-ec2-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
+  cfy blueprints upload -b nodecellar -n aws-ec2-blueprint.yaml PATH_OR_URL_OF_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 
   **vCloud**
   {{% gsTabContent "vCloud " %}}
   {{< gsHighlight  bash >}}
-  cfy blueprints upload -b nodecellar -n vcloud-blueprint.yaml URL_TO_BLUEPRINT_ARCHIVE
+  cfy blueprints upload -b nodecellar -n vcloud-blueprint.yaml PATH_OR_URL_OF_BLUEPRINT_ARCHIVE
   {{< /gsHighlight >}}
   {{% /gsTabContent %}}
 

--- a/content/manager/upload-blueprint.md
+++ b/content/manager/upload-blueprint.md
@@ -12,16 +12,17 @@ Either use a blueprint that you have written or download an [example blueprint](
 
 ## Uploading via the CLI
 
-From the Cloudify command-line interface, you can upload your blueprint to Cloudify Manager. You must specify a path to a blueprint file. Cloudify compresses the folder and its contents.
+When you upload your blueprint to Cloudify Manager from the Cloudify CLI, you must specify a path to a blueprint file or the blueprint archive. If you specify the path to the blueprint archive, you must also specify the blueprint filename.
 
-The following is an example of `upload`:
+**Example of Blueprint Archive Upload**
 {{< gsHighlight  bash >}}
-$ cfy blueprints upload -b BLUEPRINT_ID -n BLUEPRINT_FILE_LOCATION URL_TO_BLUEPRINT_ARCHIVE
-...
-
-...
+$ cfy blueprints upload -b BLUEPRINT_ID -n BLUEPRINT_FILENAME PATH_OR_URL_OF_BLUEPRINT_ARCHIVE
 {{< /gsHighlight >}}
 
+**Example of Blueprint File Upload**
+{{< gsHighlight  bash >}}
+$ cfy blueprints upload -b BLUEPRINT_ID PATH_TO_BLUEPRINT_FILE
+{{< /gsHighlight >}}
 
 ## Uploading a Blueprint via the Cloudify Web Interface
 


### PR DESCRIPTION
Upload blueprint command should be without the -p flag. 
It can be uploaded either from an unzip file which you pass with the blueprint upload command: cfy blueprints upload -b BLUEPRINT_NAME  BLUEPRINT_YAML_FILE_PATH
Or by passing the command with -n flag that will indicate the blueprint's file in the zip file (can be zip from URL or from the VM)