### PR TITLE
STAGE-693 - Add links in official documentation

### DIFF
--- a/content/apis/widgets-components.html
+++ b/content/apis/widgets-components.html
@@ -1,0 +1,14 @@
+---
+layout: null
+title: Widget Components API Reference
+category: APIs
+draft: false
+weight: 600
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="refresh" content="0;url=http://docs.cloudify.co/widgets-api/4.3.0"/>
+  </head>
+</html>

--- a/content/manager_webui/custom-widgets.md
+++ b/content/manager_webui/custom-widgets.md
@@ -123,7 +123,7 @@ In addition to listed above, you can create your own configuration fields. Examp
         Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
     ]
 ```
-All the configuration fields possibilities in `GenericField` component documentation. It is to be shared, soon.
+All the configuration fields possibilities can be found in `GenericField` component documentation (see [Widgets Components documentation]({{< relref "apis/widgets-components.html" >}})). 
 
 Configuration fields values can be fetched in `render` method using `widget.configuration` object. See [Accessing data in render()]({{< relref "manager_webui/custom-widgets.md#accessing-data-in-render" >}}) for details.
 
@@ -288,9 +288,7 @@ Take a note of how the `KeyIndicator` component is imported into the widget. Fro
 Similarly, you can import multiple components in the same line, ie:
 `let {KeyIndicator, Checkmark} = Stage.Basic;`
 
-There is a number of components ready for use in the `Stage.Basic` library. 
-
-Basic components reference documentation is to be shared.
+There is a number of components ready for use in the `Stage.Basic` library. See [Widgets Components documentation]({{< relref "apis/widgets-components.html" >}}) for details.
 
 ##### Accessing data in render()
 There can be several independent data sources for your widget. Two most commonly used are the `configuration` and `data` objects.


### PR DESCRIPTION
Please review: http://stage-docs.getcloudify.org/STAGE-693

Widgets Components API Reference uploaded. Available here: http://docs.getcloudify.org/widgets-api/4.3.0/. *STAGE-692 - Customize components documentation* not yet implemented.

Added link(s) to Widgets Components API Reference:
- in left navigation bar 
- in [Manager UI Reference > Creating Custom Widgets](http://stage-docs.getcloudify.org/STAGE-693/manager_webui/custom-widgets/) page

Maybe there's possibility to make that link contain variable for version not to update it manually each release? Can we take `"version": "4.3.0",` from `package.json` somehow?