### PR TITLE
Change cloudify.openstack.nodes.Port example

### DIFF
--- a/content/plugins/openstack.md
+++ b/content/plugins/openstack.md
@@ -1173,9 +1173,9 @@ my_port:
     resource_id: my_port_openstack_name
   relationships:
     - target: my_network
-      type: cloudify.relationships.contained_in
+      type: cloudify.relationships.connected_to
     - target: my_subnet
-      type: cloudify.relationships.depends_on
+      type: cloudify.openstack.port_connected_to_subnet
     - target: my_security_group
       type: cloudify.openstack.port_connected_to_security_group
 


### PR DESCRIPTION
Old example doesn't work in case of two or more ports connected to one instance and joined in one policy group.