### PR TITLE
Updated Widget Settings table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ outfds
 **/.bundle/
 *COMMIT_MSG
 /public
+dev
+node_modules
 
 *.py[cod]
 

--- a/content/manager_webui/custom-widgets.md
+++ b/content/manager_webui/custom-widgets.md
@@ -104,7 +104,7 @@ Option                 | Type    | Required | Default  | Description
 `initialWidth`         | string  | No       | `3`      | The default width of the widget when added to a page.
 `isReact`              | boolean | Yes      | -        | Set as `true` when writing a React widget.
 `name`                 | string  | Yes      | -        | The display name of the widget that is displayed in the **Add Widget** dialog. It is also used as the default widget name.
-`showBorder`           | boolean | No       | `false`  | Whether to display widget's border.
+`showBorder`           | boolean | No       | `true`   | Whether to display widget's border.
 `showHeader`           | boolean | No       | `true`   | Whether to display a header. If a header is not displayed, a user cannot change the widget name.
 `permission`           | string  | Yes      | -        | This property specifies which user may later access and view this widget. It may take one of the following three values defined in `Stage.GenericConfig.CUSTOM_WIDGET_PERMISSIONS` object: `CUSTOM_ADMIN_ONLY` (applies for 'sys_admin' and 'manager' roles), `CUSTOM_SYS_ADMIN_ONLY` (applies for 'sys_admin' only, `CUSTOM_ALL` (applies to all user-roles).
 

--- a/content/manager_webui/custom-widgets.md
+++ b/content/manager_webui/custom-widgets.md
@@ -90,20 +90,24 @@ As seen in the example above, there are a number of configuration fields that yo
 
 The `Stage.defineWidget` function receives a settings object with the options described in this table.
 
-Option                 | Type    | Default | Description
-----------             | -----   | ------- | -----------
-`id`                   | string  | -       | The ID of the widget definition. Must match the name of the directory into which it is placed. Required.
-`name`                 | string  | -       | The display name of the widget that is displayed in the **Add Widget** dialog. It is also used as the default widget name. Required.
-`description`          | string  | -       | Description of the widget that is displayed in the **Add Widget** dialog. **Optional**.
-`initialWidth`         | string  | -       | The default width of the widget when added to a page. Required.
-`initialHeight`        | string  | -       | The default height of the widget when added to a page. Required.
-`color`                | string  | `red`   | The color of the widget. One of the following: `red`, `orange`, `yellow`, `olive`, `green`, `teal`, `blue`, `violet`, `purple`, `pink`, `brown`, `grey` or `black`
-`showHeader`           | boolean | `true`  | Whether to display a header. If a header is not displayed, a user cannot change the widget name.
-`isReact`              | boolean | `false` | Set as `true` when writing a React widget.
-`fetchUrl`             | string/object | - | If `fetchUrl` exists, the data from the URL is fetched by the application and passed to the render and postRender methods. To fetch multiple URLs, you must pass an object where the key is a name you select for this data, and the value is the URL. It is important to note that the render is called once before the data is fetched (to enable information about loading or partial data can be displayed) and once after the data is fetched.
-`initialConfiguration` | array   | -       | A list of widget configuration options. The options are displayed when a user clicks the **`Configure`** icon in the top-right corner of the widget in edit mode. It can also be accessed in the widget, to determine the current selected configuration.
-`categories`           | array   | -       | This property specifies in which categories this widget shall be visible. It may take an array containing one or more of the values defined in `Stage.GenericConfig.CATEGORY` object: `BLUEPRINTS` ('Blueprints' category), `DEPLOYMENTS` ('Deployments'), `BUTTONS_AND_FILTERS` ('Buttons and Filters'), `CHARTS_AND_STATISTICS` ('Charts and Statistics'), `EXECUTIONS_NODES` ('Executions/Nodes'), `SYSTEM_RESOURCES` ('System Resources'), `OTHERS` ('Others'), `ALL` ('All'). **Optional**.
-`permission`           | string  | -       | This property specifies which user may later access and view this widget. It may take one of the following three values defined in `Stage.GenericConfig.CUSTOM_WIDGET_PERMISSIONS` object: `CUSTOM_ADMIN_ONLY` (applies for 'sys_admin' and 'manager' roles), `CUSTOM_SYS_ADMIN_ONLY` (applies for 'sys_admin' only, `CUSTOM_ALL` (applies to all user-roles). Mandatory.
+Option                 | Type    | Required | Default  | Description
+----------             | -----   | -------- | -------- | -----------
+`categories`           | array   | No       | `OTHERS` | This property specifies in which categories this widget shall be visible. It may take an array containing one or more of the values defined in `Stage.GenericConfig.CATEGORY` object: `BLUEPRINTS` ('Blueprints' category), `DEPLOYMENTS` ('Deployments'), `BUTTONS_AND_FILTERS` ('Buttons and Filters'), `CHARTS_AND_STATISTICS` ('Charts and Statistics'), `EXECUTIONS_NODES` ('Executions/Nodes'), `SYSTEM_RESOURCES` ('System Resources'), `OTHERS` ('Others'), `ALL` ('All').
+`color`                | string  | No       | `blue`   | The color of the widget. One of the following: `red`, `orange`, `yellow`, `olive`, `green`, `teal`, `blue`, `violet`, `purple`, `pink`, `brown`, `grey` or `black`.
+`description`          | string  | No       | -        | Description of the widget that is displayed in the **Add Widget** dialog.
+`fetchUrl`             | string/object | No | -        | If `fetchUrl` exists, the data from the URL is fetched by the application and passed to the render and postRender methods. To fetch multiple URLs, you must pass an object where the key is a name you select for this data, and the value is the URL. It is important to note that the render is called once before the data is fetched (to enable information about loading or partial data can be displayed) and once after the data is fetched.
+`hasStyle`             | boolean | No       | `false`  | Whether to use `style.css` file. File must be present in widget's main directory.
+`hasTemplate`          | boolean | No       | `false`  | Whether to use `widget.html` file as template. File must be present in widget's main directory.
+`id`                   | string  | Yes      | -        | The ID of the widget definition. Must match the name of the directory into which it is placed.
+`initialConfiguration` | array   | No       | `[]`     | A list of widget configuration options. The options are displayed when a user clicks the **`Configure`** icon in the top-right corner of the widget in edit mode. It can also be accessed in the widget, to determine the current selected configuration.
+`initialHeight`        | string  | No       | `12`     | The default height of the widget when added to a page.
+`initialWidth`         | string  | No       | `3`      | The default width of the widget when added to a page.
+`isReact`              | boolean | Yes      | -        | Set as `true` when writing a React widget.
+`name`                 | string  | Yes      | -        | The display name of the widget that is displayed in the **Add Widget** dialog. It is also used as the default widget name.
+`showBorder`           | boolean | No       | `false`  | Whether to display widget's border.
+`showHeader`           | boolean | No       | `true`   | Whether to display a header. If a header is not displayed, a user cannot change the widget name.
+`permission`           | string  | Yes      | -        | This property specifies which user may later access and view this widget. It may take one of the following three values defined in `Stage.GenericConfig.CUSTOM_WIDGET_PERMISSIONS` object: `CUSTOM_ADMIN_ONLY` (applies for 'sys_admin' and 'manager' roles), `CUSTOM_SYS_ADMIN_ONLY` (applies for 'sys_admin' only, `CUSTOM_ALL` (applies to all user-roles).
+
 
 #### initialConfiguration
 `initialConfiguration` supports 4 generic pre-made config fields (see `fetchUrl` for example):
@@ -313,6 +317,7 @@ Stage.defineWidget({
     initialConfiguration: [
         {id: 'confText', name: 'Conf Item',  placeHolder: 'Configuration text item', default: 'Conf text', type: Stage.Basic.GenericField.STRING_TYPE}
     ],
+    permission: Stage.GenericConfig.CUSTOM_WIDGET_PERMISSIONS.CUSTOM_ALL,
 
     fetchData(widget, toolbox){
         return Promise.resolve({fetchedText: 'Fetched text'});

--- a/content/manager_webui/overview.md
+++ b/content/manager_webui/overview.md
@@ -36,7 +36,7 @@ If you have a `user` role, your ability to create dashboard pages and manage wid
 To enter Edit mode, click the dropdown arrow next to your user name and select **Edit Mode**. For more information about actions you can perform in edit mode, [click here]({{< relref "manager_webui/configure-display.md" >}}).
 
 ### Custom Widgets
-In addition to the default widgets, you can create your own and add them to the widgets catalog. 
+In addition to the default widgets, you can [create your own]({{< relref "manager_webui/custom-widgets.md" >}}) and add them to the widgets catalog. 
 
 ## Community Version
 As of Release 4.2, Cloudify Web UI is also available in `Community` version (Open Source). This edition keeps all the features of the `Premium` with the exception of the following:


### PR DESCRIPTION
In Widget Settings table:
* Added *Required* column 
* Added missing settings (`hasTemplate` and `hasStyle`)
* Sorted settings in alphabetical order

That fix is for 4.3.