### PR TITLE
Implement split build and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     # The build job for master and staging branches that excludes Google Tag Manager
     build:
         docker:
-            - image: alrayyes/alpine-hugo-git-bash:latest
+            - image: andthensome/alpine-hugo-git-bash:latest
         working_directory: ~/project
         steps:
             # Update apt-get

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
     deploy-staging:
         docker:
-            - image: gambtho/awscli_node:latest
+            - image: xueshanf/awscli:latest
         working_directory: ~/project
         steps:
             # Set the signature version for the S3 auth
@@ -64,7 +64,7 @@ jobs:
 
     deploy-prod:
         docker:
-            - image: gambtho/awscli_node:latest
+            - image: xueshanf/awscli:latest
         working_directory: ~/project
         steps:
             - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ jobs:
                 name: Update ca-certificates
                 command: |
                     apk add ca-certificates && rm -rf /var/cache/apk/*
-                    mv ./mycert.crt /usr/local/share/ca-certificates/mycert.crt
                     update-ca-certificates
             - attach_workspace:
                 at: ~/aws

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,9 @@ workflows:
   build-deploy:
     jobs:
       - build
-        filters:
-          branches:
-            ignore: (master|/.*-build/)
+        # filters:
+        #   branches:
+        #     ignore: (master|/.*-build/)
     #   - build-prod
     #     filters:
     #         branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
         steps:
             - attach_workspace:
                 at: ~/project
-        steps:
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication
@@ -60,7 +59,6 @@ jobs:
         steps:
             - attach_workspace:
                 at: ~/project
-        steps:
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,13 +76,13 @@ workflows:
             - build
           filters:
             branches:
-              ignore: docdock-circle
+              only: docdock-circle
       - deploy-prod:
           requires:
             - build
           filters:
             branches:
-              only: docdock-circle     
+              ignore: docdock-circle     
         # filters:
         #   branches:
         #     ignore: (master|/.*-build/)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,17 +96,16 @@ workflows:
             - build
           filters:
             branches:
-              ignore: master
-#                - /.*-circle/
+              ignore: (master|/.*-circle/)
       - deploy-dev:
           requires:
             - build
           filters:
             branches:
               only: master
-    #   - deploy-prod:
-    #       requires:
-    #         - build
-    #       filters:
-    #         branches:
-    #           only: /.*-circle/
+      - deploy-prod:
+          requires:
+            - build
+          filters:
+            branches:
+              only: /.*-circle/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 cp public s3://stage-docs.getcloudify.org/docdock/staging/$CIRCLE_BRANCH --acl public-read
+                command: aws s3 cp public s3://stage-docs.getcloudify.org/docdock/staging/dev --acl public-read
 
     deploy-dev:
         docker:
@@ -96,7 +96,9 @@ workflows:
             - build
           filters:
             branches:
-              ignore: (master|/.*-circle/)
+              ignore:
+                - master
+                - /.*-circle/
       - deploy-dev:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,21 +20,25 @@ jobs:
                 paths:
                     - public
 
-    # # The build job for production branches that includes Google Tag Manager
-    # "build-prod":
-    #     docker:
-    #         - image: gambtho/awscli_node:latest
-    #     working_directory: ~/project
-    #     steps:
-    #         # Checkout the code from the branch into the working_directory
-    #         - checkout
-    #         # Log the current branch
-    #         - run:
-    #             name: Show current branch
-    #             command: echo ${CIRCLE_BRANCH}
-    #         - run:
-    #             name: Building site
-    #             command: HUGO_ENV=production hugo -v
+    # The build job for production branches that includes Google Tag Manager
+    build-prod:
+        docker:
+            - image: jmminy/alpine-hugo-git-bash:latest
+        working_directory: ~/project
+        steps:
+            # Checkout the code from the branch into the working_directory
+            - checkout
+            # Log the current branch
+            - run:
+                name: Show current branch
+                command: echo ${CIRCLE_BRANCH}
+            - run:
+                name: Building site
+                command: HUGO_ENV=production hugo -v
+            - persist_to_workspace:
+                root: .
+                paths:
+                    - public
 
     deploy-staging:
         docker:
@@ -82,13 +86,20 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --delete --acl public-read
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/ --delete --acl public-read
 
 workflows:
   version: 2
   build-deploy:
     jobs:
       - build
+          filters:
+            branches:
+              ignore: /.*-build/      
+      - build-prod
+          filters:
+            branches:
+              only: /.*-build/
       - deploy-staging:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ jobs:
             - run:
                 name: Update apt-get
                 command: apt-get -y -qq update
+            # Install git
+            - run:
+                name: Install Git
+                command: apt-get -y install git
             # Download and install Hugo 0.36
             - run:
                 name: Install Hugo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,32 @@
 version: 2
 jobs:
-    # The build job for master and staging branches that excludes Google Tag Manager
-    build:
-        docker:
-            - image: gambtho/awscli_node:latest
-        working_directory: ~/project
-        steps:
-            # Update apt-get
-            - run:
-                name: Update apt-get
-                command: apt-get -y -qq update
-            # Download and install Hugo 0.36
-            - run:
-                name: Install Hugo
-                command: |
-                    apt-get -y install wget
-                    wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
-                    dpkg -i hugo*.deb
-                    rm hugo*.deb
-            # Checkout the code from the branch into the working_directory
-            - checkout
-            # Log the current branch
-            - run:
-                name: Show current branch
-                command: echo ${CIRCLE_BRANCH}
-            - run:
-                name: Building site
-                command: hugo -v
+  # The build job for master and staging branches that excludes Google Tag Manager
+  build:
+      docker:
+          - image: gambtho/awscli_node:latest
+      working_directory: ~/project
+      steps:
+          # Update apt-get
+          - run:
+              name: Update apt-get
+              command: apt-get -y -qq update
+          # Download and install Hugo 0.36
+          - run:
+              name: Install Hugo
+              command: |
+                  apt-get -y install wget
+                  wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
+                  dpkg -i hugo*.deb
+                  rm hugo*.deb
+          # Checkout the code from the branch into the working_directory
+          - checkout
+          # Log the current branch
+          - run:
+              name: Show current branch
+              command: echo ${CIRCLE_BRANCH}
+          - run:
+              name: Building site
+              command: hugo -v
 
     # # The build job for production branches that includes Google Tag Manager
     # build-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
 
     deploy-staging:
         docker:
-            - image: gambtho/awscli_node:latest
+            - image: anigeo/awscli:latest
         working_directory: ~/project
         steps:
             # Set the signature version for the S3 auth
@@ -80,7 +80,7 @@ jobs:
 
     deploy-prod:
         docker:
-            - image: gambtho/awscli_node:latest
+            - image: anigeo/awscli:latest
         working_directory: ~/project
         steps:
             - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,21 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.2 --acl public-read
+                command: aws s3 cp public s3://stage-docs.getcloudify.org/docdock/staging/${CIRCLE_BRANCH} --acl public-read
+
+    deploy-dev:
+        docker:
+            - image: xueshanf/awscli:latest
+        working_directory: ~/project
+        steps:
+            # Set the signature version for the S3 auth
+            - run:
+                name: Setting Signature Version 4 for S3 Request Authentication
+                command: aws configure set default.s3.signature_version s3v4
+            # Deploy to the S3 bucket corresponding to the current branch
+            - run:
+                name: Deploy to S3
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/staging/dev --delete --acl public-read
 
     deploy-prod:
         docker:
@@ -64,7 +78,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --delete --acl public-read
 
 workflows:
   version: 2
@@ -76,35 +90,18 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /.*-circle/
-      - deploy-prod:
+              ignore: |
+#                - /.*-circle/
+                - master
+      - deploy-dev:
           requires:
             - build
           filters:
             branches:
-              only: /.*-circle/     
-        # filters:
-        #   branches:
-        #     ignore: (master|/.*-build/)
-    #   - build-prod
-    #     filters:
-    #         branches:
-    #           only: (master|/.*-build/)
-    #   - deploy-staging:
-    #       requires:
-    #         - build-dev-staging
-    #       filters:
-    #         branches:
-    #           only: staging
-    #   - deploy-dev:
-    #       requires:
-    #         - build-dev-staging
-    #       filters:
-    #         branches:
-    #           only: master
+              only: master
     #   - deploy-prod:
     #       requires:
-    #         - build-prod
+    #         - build
     #       filters:
     #         branches:
-    #           only: /.*-build/
+    #           only: /.*-circle/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
             - image: xueshanf/awscli:latest
         working_directory: ~/project
         steps:
+            - attach_workspace:
+                at: ~/project
+        steps:
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication
@@ -54,6 +57,9 @@ jobs:
         docker:
             - image: xueshanf/awscli:latest
         working_directory: ~/project
+        steps:
+            - attach_workspace:
+                at: ~/project
         steps:
             # Set the signature version for the S3 auth
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,35 @@
 version: 2
 jobs:
-  # The build job for master and staging branches that excludes Google Tag Manager
-  build:
-      docker:
-          - image: gambtho/awscli_node:latest
-      working_directory: ~/project
-      steps:
-          # Update apt-get
-          - run:
-              name: Update apt-get
-              command: apt-get -y -qq update
-          # Download and install Hugo 0.36
-          - run:
-              name: Install Hugo
-              command: |
-                  apt-get -y install wget
-                  wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
-                  dpkg -i hugo*.deb
-                  rm hugo*.deb
-          # Checkout the code from the branch into the working_directory
-          - checkout
-          # Log the current branch
-          - run:
-              name: Show current branch
-              command: echo ${CIRCLE_BRANCH}
-          - run:
-              name: Building site
-              command: hugo -v
+    # The build job for master and staging branches that excludes Google Tag Manager
+    build:
+        docker:
+            - image: gambtho/awscli_node:latest
+        working_directory: ~/project
+        steps:
+            # Update apt-get
+            - run:
+                name: Update apt-get
+                command: apt-get -y -qq update
+            # Download and install Hugo 0.36
+            - run:
+                name: Install Hugo
+                command: |
+                    apt-get -y install wget
+                    wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
+                    dpkg -i hugo*.deb
+                    rm hugo*.deb
+            # Checkout the code from the branch into the working_directory
+            - checkout
+            # Log the current branch
+            - run:
+                name: Show current branch
+                command: echo ${CIRCLE_BRANCH}
+            - run:
+                name: Building site
+                command: hugo -v
 
     # # The build job for production branches that includes Google Tag Manager
-    # build-prod:
+    # "build-prod":
     #     docker:
     #         - image: gambtho/awscli_node:latest
     #     working_directory: ~/project
@@ -88,8 +88,8 @@ workflows:
     jobs:
       - build
         filters:
-            branches:
-              ignore: (master|/.*-build/)
+          branches:
+            ignore: (master|/.*-build/)
     #   - build-prod
     #     filters:
     #         branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
                 paths:
                     - public
 
+    # Deploy for branches other than master or -build to /staging/{branch}
     deploy-staging:
         docker:
             - image: xueshanf/awscli:latest
@@ -56,6 +57,7 @@ jobs:
                 name: Deploy to S3
                 command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/staging/${CIRCLE_BRANCH} --delete --acl public-read
 
+    # Deploy for master to push to /staging/dev
     deploy-dev:
         docker:
             - image: xueshanf/awscli:latest
@@ -72,6 +74,7 @@ jobs:
                 name: Deploy to S3
                 command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/staging/dev --delete --acl public-read
 
+    # Deploy for -build to push to /{version} without -build
     deploy-prod:
         docker:
             - image: xueshanf/awscli:latest
@@ -116,7 +119,7 @@ workflows:
               only: master
       - deploy-prod:
           requires:
-            - build
+            - build-prod
           filters:
             branches:
               only: /.*-build/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,8 @@ workflows:
             - build
           filters:
             branches:
-              ignore: |
+              ignore: master
 #                - /.*-circle/
-                - master
       - deploy-dev:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
     # The build job for master and staging branches that excludes Google Tag Manager
-    build-dev-staging:
+    build:
         docker:
             - image: gambtho/awscli_node:latest
         working_directory: ~/project
@@ -28,33 +28,33 @@ jobs:
                 name: Building site
                 command: hugo -v
 
-    # The build job for production branches that includes Google Tag Manager
-    build-prod:
-        docker:
-            - image: gambtho/awscli_node:latest
-        working_directory: ~/project
-        steps:
-            # Update apt-get
-            - run:
-                name: Update apt-get
-                command: apt-get -y -qq update
-            # Download and install Hugo 0.36
-            - run:
-                name: Install Hugo
-                command: |
-                    apt-get -y install wget
-                    wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
-                    dpkg -i hugo*.deb
-                    rm hugo*.deb
-            # Checkout the code from the branch into the working_directory
-            - checkout
-            # Log the current branch
-            - run:
-                name: Show current branch
-                command: echo ${CIRCLE_BRANCH}
-            - run:
-                name: Building site
-                command: HUGO_ENV=production hugo -v
+    # # The build job for production branches that includes Google Tag Manager
+    # build-prod:
+    #     docker:
+    #         - image: gambtho/awscli_node:latest
+    #     working_directory: ~/project
+    #     steps:
+    #         # Update apt-get
+    #         - run:
+    #             name: Update apt-get
+    #             command: apt-get -y -qq update
+    #         # Download and install Hugo 0.36
+    #         - run:
+    #             name: Install Hugo
+    #             command: |
+    #                 apt-get -y install wget
+    #                 wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
+    #                 dpkg -i hugo*.deb
+    #                 rm hugo*.deb
+    #         # Checkout the code from the branch into the working_directory
+    #         - checkout
+    #         # Log the current branch
+    #         - run:
+    #             name: Show current branch
+    #             command: echo ${CIRCLE_BRANCH}
+    #         - run:
+    #             name: Building site
+    #             command: HUGO_ENV=production hugo -v
 
     # deploy-staging:
     #     docker:
@@ -86,14 +86,14 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build-dev-staging
+      - build
         filters:
             branches:
               ignore: (master|/.*-build/)
-      - build-prod
-        filters:
-            branches:
-              only: (master|/.*-build/)
+    #   - build-prod
+    #     filters:
+    #         branches:
+    #           only: (master|/.*-build/)
     #   - deploy-staging:
     #       requires:
     #         - build-dev-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     # The build job for master and staging branches that excludes Google Tag Manager
     build:
         docker:
-            - image: ceregousa/ubuntu-git:latest
+            - image: alrayyes/docker-alpine-hugo-git-bash:latest
         working_directory: ~/project
         steps:
             # Update apt-get
@@ -14,14 +14,14 @@ jobs:
             # - run:
             #     name: Install Git
             #     command: apt-get -y install git
-            # Download and install Hugo 0.36
-            - run:
-                name: Install Hugo
-                command: |
-                    apt-get -y install wget
-                    wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
-                    dpkg -i hugo*.deb
-                    rm hugo*.deb
+            # # Download and install Hugo 0.36
+            # - run:
+            #     name: Install Hugo
+            #     command: |
+            #         apt-get -y install wget
+            #         wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
+            #         dpkg -i hugo*.deb
+            #         rm hugo*.deb
             # Checkout the code from the branch into the working_directory
             - checkout
             # Log the current branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 cp public s3://stage-docs.getcloudify.org/docdock/staging/${CIRCLE_BRANCH} --acl public-read
+                command: aws s3 cp public s3://stage-docs.getcloudify.org/docdock/staging/$CIRCLE_BRANCH --acl public-read
 
     deploy-dev:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,11 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build
+      - build:
           filters:
             branches:
-              ignore: /.*-build/      
-      - build-prod
+              ignore: /.*-build/
+      - build-prod:
           filters:
             branches:
               only: /.*-build/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ jobs:
             - image: andthensome/alpine-hugo-git-bash:latest
         working_directory: ~/project
         steps:
-            # Update apt-get
-            - run:
-                name: Update apt-get
-                command: apt-get -y -qq update
+            # # Update apt-get
+            # - run:
+            #     name: Update apt-get
+            #     command: apt-get -y -qq update
             # # Install git
             # - run:
             #     name: Install Git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ jobs:
             - run:
                 name: Building site
                 command: hugo -v
+            - persist_to_workspace:
+                root: .
+                paths:
+                    - public
 
     # # The build job for production branches that includes Google Tag Manager
     # "build-prod":
@@ -75,6 +79,8 @@ jobs:
             - image: gambtho/awscli_node:latest
         working_directory: ~/project
         steps:
+            - attach_workspace:
+                at: ~/project
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication
@@ -82,7 +88,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 sync ~/project/public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     # The build job for master and staging branches that excludes Google Tag Manager
     build:
         docker:
-            - image: alrayyes/docker-alpine-hugo-git-bash:latest
+            - image: alrayyes/alpine-hugo-git-bash:latest
         working_directory: ~/project
         steps:
             # Update apt-get

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,9 @@ jobs:
             - image: anigeo/awscli:latest
         working_directory: ~/aws
         steps:
-            -run: 
-                name: Update ca-certificates
-                command: |
-                    apk add ca-certificates && rm -rf /var/cache/apk/*
-                    update-ca-certificates
+            -run: |
+                apk add ca-certificates && rm -rf /var/cache/apk/*
+                update-ca-certificates
             - attach_workspace:
                 at: ~/aws
             # Set the signature version for the S3 auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/staging --delete --acl public-read
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/staging/${CIRCLE_BRANCH} --delete --acl public-read
 
     deploy-dev:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 cp public s3://stage-docs.getcloudify.org/docdock/staging/dev --acl public-read
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/staging --delete --acl public-read
 
     deploy-dev:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
     deploy-staging:
         docker:
-            - image: anigeo/awscli:latest
+            - image: gambtho/awscli_node:latest
         working_directory: ~/project
         steps:
             # Set the signature version for the S3 auth
@@ -64,14 +64,11 @@ jobs:
 
     deploy-prod:
         docker:
-            - image: anigeo/awscli:latest
-        working_directory: ~/aws
+            - image: gambtho/awscli_node:latest
+        working_directory: ~/project
         steps:
-            -run: |
-                apk add ca-certificates && rm -rf /var/cache/apk/*
-                update-ca-certificates
             - attach_workspace:
-                at: ~/aws
+                at: ~/project
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,22 +6,6 @@ jobs:
             - image: jmminy/alpine-hugo-git-bash:latest
         working_directory: ~/project
         steps:
-            # # Update apt-get
-            # - run:
-            #     name: Update apt-get
-            #     command: apt-get -y -qq update
-            # # Install git
-            # - run:
-            #     name: Install Git
-            #     command: apt-get -y install git
-            # # Download and install Hugo 0.36
-            # - run:
-            #     name: Install Hugo
-            #     command: |
-            #         apt-get -y install wget
-            #         wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
-            #         dpkg -i hugo*.deb
-            #         rm hugo*.deb
             # Checkout the code from the branch into the working_directory
             - checkout
             # Log the current branch
@@ -81,10 +65,10 @@ jobs:
     deploy-prod:
         docker:
             - image: anigeo/awscli:latest
-        working_directory: ~/project
+        working_directory: ~/aws
         steps:
             - attach_workspace:
-                at: ~/project
+                at: ~/aws
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,17 +3,17 @@ jobs:
     # The build job for master and staging branches that excludes Google Tag Manager
     build:
         docker:
-            - image: ubuntu:latest
+            - image: ceregousa/ubuntu-git:latest
         working_directory: ~/project
         steps:
             # Update apt-get
             - run:
                 name: Update apt-get
                 command: apt-get -y -qq update
-            # Install git
-            - run:
-                name: Install Git
-                command: apt-get -y install git
+            # # Install git
+            # - run:
+            #     name: Install Git
+            #     command: apt-get -y install git
             # Download and install Hugo 0.36
             - run:
                 name: Install Hugo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+                command: aws s3 sync ~/project/public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,37 +56,49 @@ jobs:
     #             name: Building site
     #             command: HUGO_ENV=production hugo -v
 
-    # deploy-staging:
-    #     docker:
-    #         - image: gambtho/awscli_node:latest
-    #     working_directory: ~/project
-    #         # Set the signature version for the S3 auth
-    #         - run:
-    #             name: Setting Signature Version 4 for S3 Request Authentication
-    #             command: aws configure set default.s3.signature_version s3v4
-    #         # Deploy to the S3 bucket corresponding to the current branch
-    #         - run:
-    #             name: Deploy to S3
-    #             command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+    deploy-staging:
+        docker:
+            - image: gambtho/awscli_node:latest
+        working_directory: ~/project
+            # Set the signature version for the S3 auth
+            - run:
+                name: Setting Signature Version 4 for S3 Request Authentication
+                command: aws configure set default.s3.signature_version s3v4
+            # Deploy to the S3 bucket corresponding to the current branch
+            - run:
+                name: Deploy to S3
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
 
-    # deploy-prod:
-    #     docker:
-    #         - image: gambtho/awscli_node:latest
-    #     working_directory: ~/project
-    #         # Set the signature version for the S3 auth
-    #         - run:
-    #             name: Setting Signature Version 4 for S3 Request Authentication
-    #             command: aws configure set default.s3.signature_version s3v4
-    #         # Deploy to the S3 bucket corresponding to the current branch
-    #         - run:
-    #             name: Deploy to S3
-    #             command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+    deploy-prod:
+        docker:
+            - image: gambtho/awscli_node:latest
+        working_directory: ~/project
+            # Set the signature version for the S3 auth
+            - run:
+                name: Setting Signature Version 4 for S3 Request Authentication
+                command: aws configure set default.s3.signature_version s3v4
+            # Deploy to the S3 bucket corresponding to the current branch
+            - run:
+                name: Deploy to S3
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
 
 workflows:
   version: 2
   build-deploy:
     jobs:
       - build
+      - deploy-staging:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: docdock-circle
+      - deploy-prod:
+          requires:
+            - build
+          filters:
+            branches:
+              only: docdock-circle     
         # filters:
         #   branches:
         #     ignore: (master|/.*-build/)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,18 +26,6 @@ jobs:
     #         - image: gambtho/awscli_node:latest
     #     working_directory: ~/project
     #     steps:
-    #         # Update apt-get
-    #         - run:
-    #             name: Update apt-get
-    #             command: apt-get -y -qq update
-    #         # Download and install Hugo 0.36
-    #         - run:
-    #             name: Install Hugo
-    #             command: |
-    #                 apt-get -y install wget
-    #                 wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
-    #                 dpkg -i hugo*.deb
-    #                 rm hugo*.deb
     #         # Checkout the code from the branch into the working_directory
     #         - checkout
     #         # Log the current branch
@@ -60,7 +48,7 @@ jobs:
             # Deploy to the S3 bucket corresponding to the current branch
             - run:
                 name: Deploy to S3
-                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.2 --acl public-read
 
     deploy-prod:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ workflows:
             branches:
               ignore:
                 - master
-                - /.*-circle/
+                - /.*-build/
       - deploy-dev:
           requires:
             - build
@@ -110,4 +110,4 @@ workflows:
             - build
           filters:
             branches:
-              only: /.*-circle/
+              only: /.*-build/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     # The build job for master and staging branches that excludes Google Tag Manager
     build:
         docker:
-            - image: andthensome/alpine-hugo-git-bash:latest
+            - image: jmminy/alpine-hugo-git-bash:latest
         working_directory: ~/project
         steps:
             # # Update apt-get

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     # The build job for master and staging branches that excludes Google Tag Manager
     build:
         docker:
-            - image: gambtho/awscli_node:latest
+            - image: ubuntu:latest
         working_directory: ~/project
         steps:
             # Update apt-get

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
         docker:
             - image: gambtho/awscli_node:latest
         working_directory: ~/project
+        steps:
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication
@@ -73,6 +74,7 @@ jobs:
         docker:
             - image: gambtho/awscli_node:latest
         working_directory: ~/project
+        steps:
             # Set the signature version for the S3 auth
             - run:
                 name: Setting Signature Version 4 for S3 Request Authentication

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,38 @@
 version: 2
 jobs:
-    # The build job
-    build:
-        working_directory: ~/project
+    # The build job for master and staging branches that excludes Google Tag Manager
+    build-dev-staging:
         docker:
             - image: gambtho/awscli_node:latest
+        working_directory: ~/project
+        steps:
+            # Update apt-get
+            - run:
+                name: Update apt-get
+                command: apt-get -y -qq update
+            # Download and install Hugo 0.36
+            - run:
+                name: Install Hugo
+                command: |
+                    apt-get -y install wget
+                    wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
+                    dpkg -i hugo*.deb
+                    rm hugo*.deb
+            # Checkout the code from the branch into the working_directory
+            - checkout
+            # Log the current branch
+            - run:
+                name: Show current branch
+                command: echo ${CIRCLE_BRANCH}
+            - run:
+                name: Building site
+                command: hugo -v
+
+    # The build job for production branches that includes Google Tag Manager
+    build-prod:
+        docker:
+            - image: gambtho/awscli_node:latest
+        working_directory: ~/project
         steps:
             # Update apt-get
             - run:
@@ -27,11 +55,60 @@ jobs:
             - run:
                 name: Building site
                 command: HUGO_ENV=production hugo -v
-            # Set the signature version for the S3 auth
-            - run:
-                name: Setting Signature Version 4 for S3 Request Authentication
-                command: aws configure set default.s3.signature_version s3v4
-            # Deploy to the S3 bucket corresponding to the current branch
-            - run:
-                name: Deploy to S3
-                command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock --acl public-read
+
+    # deploy-staging:
+    #     docker:
+    #         - image: gambtho/awscli_node:latest
+    #     working_directory: ~/project
+    #         # Set the signature version for the S3 auth
+    #         - run:
+    #             name: Setting Signature Version 4 for S3 Request Authentication
+    #             command: aws configure set default.s3.signature_version s3v4
+    #         # Deploy to the S3 bucket corresponding to the current branch
+    #         - run:
+    #             name: Deploy to S3
+    #             command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+
+    # deploy-prod:
+    #     docker:
+    #         - image: gambtho/awscli_node:latest
+    #     working_directory: ~/project
+    #         # Set the signature version for the S3 auth
+    #         - run:
+    #             name: Setting Signature Version 4 for S3 Request Authentication
+    #             command: aws configure set default.s3.signature_version s3v4
+    #         # Deploy to the S3 bucket corresponding to the current branch
+    #         - run:
+    #             name: Deploy to S3
+    #             command: aws s3 sync public s3://stage-docs.getcloudify.org/docdock/4.3 --acl public-read
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build-dev-staging
+        filters:
+            branches:
+              ignore: (master|/.*-build/)
+      - build-prod
+        filters:
+            branches:
+              only: (master|/.*-build/)
+    #   - deploy-staging:
+    #       requires:
+    #         - build-dev-staging
+    #       filters:
+    #         branches:
+    #           only: staging
+    #   - deploy-dev:
+    #       requires:
+    #         - build-dev-staging
+    #       filters:
+    #         branches:
+    #           only: master
+    #   - deploy-prod:
+    #       requires:
+    #         - build-prod
+    #       filters:
+    #         branches:
+    #           only: /.*-build/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,13 +76,13 @@ workflows:
             - build
           filters:
             branches:
-              only: docdock-circle
+              ignore: /.*-circle/
       - deploy-prod:
           requires:
             - build
           filters:
             branches:
-              ignore: docdock-circle     
+              only: /.*-circle/     
         # filters:
         #   branches:
         #     ignore: (master|/.*-build/)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,12 @@ jobs:
             - image: anigeo/awscli:latest
         working_directory: ~/aws
         steps:
+            -run: 
+                name: Update ca-certificates
+                command: |
+                    apk add ca-certificates && rm -rf /var/cache/apk/*
+                    mv ./mycert.crt /usr/local/share/ca-certificates/mycert.crt
+                    update-ca-certificates
             - attach_workspace:
                 at: ~/aws
             # Set the signature version for the S3 auth


### PR DESCRIPTION
- Build includes Google Tag Manager for production only
- Deploy pushes production to version directories, master to staging/dev and others to staging/{branch}