### PR TITLE
IP addresses should be configured prior to install

### DIFF
--- a/content/install_maintain/installation/prerequisites.md
+++ b/content/install_maintain/installation/prerequisites.md
@@ -42,6 +42,8 @@ Cloudify Manager requires at least 2 network interfaces:
 * Private - This interface is dedicated for communication with other Cloudify components, including agents and cluster members.
 * Public - This interface is dedicated for connections to the Cloudify Manager with the Cloudify CLI and Cloudify Console.
 
+Unless using a [Cloudify Manager image]({{< relref "install_maintain/installation/manager-image.md" >}}), these should be configured with their IP addresses prior to starting the installation.
+
 ## Prerequisite Packages
 
 There are specific packages that are commonly included in RHEL/CentOS. You must have these packages installed before you install Cloudify Manager:

--- a/content/install_maintain/installation/prerequisites.md
+++ b/content/install_maintain/installation/prerequisites.md
@@ -37,12 +37,10 @@ You can also create a Cloudify Manager with the Amazon AWS, OpenStack, or Docker
 
 ## Network Interfaces
 
-Cloudify Manager requires at least 2 network interfaces:
+Cloudify Manager requires at least 2 network interfaces configured with IP addresses:
 
 * Private - This interface is dedicated for communication with other Cloudify components, including agents and cluster members.
 * Public - This interface is dedicated for connections to the Cloudify Manager with the Cloudify CLI and Cloudify Console.
-
-Unless using a [Cloudify Manager image]({{< relref "install_maintain/installation/manager-image.md" >}}), these should be configured with their IP addresses prior to starting the installation.
 
 ## Prerequisite Packages
 


### PR DESCRIPTION
Cloudify bootstrap does not configure the IP addresses on the private/public interfaces if they are not present, and if they are not configured the bootstrap will fail with an error about RabbitMQ connectivity. This is confusing for new users, reported multiple times eg  https://groups.google.com/forum/#!topic/cloudify-users/7gB8tIEv9E0 .

This patch adds a one line note to add configuration of IP addresses to pre-requisites, if they are not using a VM image-based install.