### PR TITLE
Update packaging-your-plugin.md

### DIFF
--- a/content/developer/writing_plugins/packaging-your-plugin.md
+++ b/content/developer/writing_plugins/packaging-your-plugin.md
@@ -13,6 +13,7 @@ aliases: /plugins/packaging-your-plugin/
 
 # Requirements
 
+- You must use the version of Wagon that is required by the oldest version of Cloudify that your Wagon should support. For example, if you need to support Cloudify 3.4.2, you should use Wagon version 0.3.2. Verify the [Cloudify Agent](https://github.com/cloudify-cosmo/cloudify-agent/blob/master/setup.py) dependencies for the Cloudify versions required.
 - Cloudify in your local Python path.
 - A zip archive of the plugin package, such as `https://github.com/cloudify-cosmo/cloudify-openstack-plugin/archive/2.2.0.zip`.
 - A `constraints.txt` with any specific constraints.
@@ -30,7 +31,14 @@ _Wagons are often specific to the OS/Platform/Distribution/Architecture that the
 
 # Usage
 
-Run the following command to create the wagon:
+When using Wagon version 0.3.2:
+
+```
+$ wagon create -s path/to/python/project.zip -a '--no-cache-dir -c path/to/constraints.txt'
+```
+
+
+When using Wagon version 0.6.1:
 
 ```
 $ wagon create path/to/python/project.zip -a '--no-cache-dir -c path/to/constraints.txt'

--- a/content/developer/writing_plugins/packaging-your-plugin.md
+++ b/content/developer/writing_plugins/packaging-your-plugin.md
@@ -8,7 +8,7 @@ aliases: /plugins/packaging-your-plugin/
 ---
 
 
-[Wagon](https://github.org/cloudify-cosmo/wagon) is a tool for packaging sets of Python wheels.
+[Wagon](https://github.com/cloudify-cosmo/wagon) is a tool for packaging sets of Python wheels.
 
 
 # Requirements
@@ -33,7 +33,7 @@ _Wagons are often specific to the OS/Platform/Distribution/Architecture that the
 Run the following command to create the wagon:
 
 ```
-$ wagon create -s path/to/python/project.zip -a '--no-cache-dir -c path/to/constraints.txt'
+$ wagon create path/to/python/project.zip -a '--no-cache-dir -c path/to/constraints.txt'
 ```
 
 


### PR DESCRIPTION
fixed link to Wagon docs in the first line and removed "-s" parameter in the usage section (path to source archive in wagon is passed without any additional parameter)