### PR TITLE
Note OpenStack Newton support

### DIFF
--- a/content/working_with/official_plugins/openstack.md
+++ b/content/working_with/official_plugins/openstack.md
@@ -27,6 +27,7 @@ For more information about OpenStack, see [https://www.openstack.org/](https://w
 
 # Compatibility
 
+* **Newton** official support\*
 * **Mitaka** official support\*
 * **Liberty** official support\*
 * **Kilo** official support

--- a/content/working_with/official_plugins/openstack.md
+++ b/content/working_with/official_plugins/openstack.md
@@ -36,10 +36,10 @@ For more information about OpenStack, see [https://www.openstack.org/](https://w
 
 The OpenStack plugin uses various OpenStack client packages. The versions used in the OpenStack plugin are as follows:
 
-  * [Nova client](https://github.com/openstack/python-novaclient) - 2.26.0
-  * [Neutron client](https://github.com/openstack/python-neutronclient) - 2.6.0
-  * [Cinder client](https://github.com/openstack/python-cinderclient) - 1.2.2
-  * [Keystone client](https://github.com/openstack/python-keystoneclient) - 1.6.0
+  * [Nova client](https://github.com/openstack/python-novaclient) - 7.0.0
+  * [Neutron client](https://github.com/openstack/python-neutronclient) - 6.0.0
+  * [Cinder client](https://github.com/openstack/python-cinderclient) - 1.9.0
+  * [Keystone client](https://github.com/openstack/python-keystoneclient) - 3.5.0
 
 # OpenStack Configuration
 


### PR DESCRIPTION
According to the Cloudify 4.2 release announcement, OpenStack support was upgraded to Newton:
https://cloudify.co/2017/12/05/cloudify-4-2-landed-security-control-true-self-service/

This patch adds that version to the list of compatible versions in the plugin documentation.