### PR TITLE
Removed the security auditing branch

### DIFF
--- a/content/about/manager_architecture/security.md
+++ b/content/about/manager_architecture/security.md
@@ -164,23 +164,3 @@ In case you renew the certificate, just update it in the manager, under /etc/clo
 * Use of PostgreSQL ensures that secrets are replicated across all Cloudify Manager instances within a cluster, as part of HA.<br>
 
 For more information about the secrets store, [click here]({{< relref "working_with/manager/using-secrets.md" >}}).
-
-
-## Auditing
-Security operations, such as authenticating success or failure and user details, are audited in dedicated log file on the management server.<br>
-The default configuration is:
-
-{{< highlight  yaml  >}}
-audit_log_file: /var/log/cloudify/rest-security-audit.log
-audit_log_level: INFO
-audit_log_file_size_MB: 100
-audit_log_files_backup_count: 20
-{{< /highlight >}}
-
-* **`audit_log_file`** Sets the full path to the auditing file on Cloudify Manager.<br>
-* **`audit_log_level`** Modifying the log level produces more or less elaborate security auditing. Valid values are:
-CRITICAL, ERROR, WARNING, INFO or DEBUG.<br>
-* **`audit_log_file_size_MB`** Limits the log file size. By default, the file is limited to 100 MB. When the file reaches
-that size, it is renamed with the extension ".1", and a new log file is created (older files are renamed
-with the extension ".2", ".3" and so on).<br>
-* **`audit_log_files_backup_count`** Sets the maximum number of old log files to keep. By default, this value is 20, meaning that up to 20 log files can be created, after which the oldest file is removed.


### PR DESCRIPTION
I've removed the security auditing section as we don't have it in Cloudify 4.x