### PR TITLE
added support dir and support script

### DIFF
--- a/support/cloudify-vnf-story/upload-secrets.sh
+++ b/support/cloudify-vnf-story/upload-secrets.sh
@@ -1,0 +1,16 @@
+. ./env
+
+cfy secrets delete openstack_auth_url >/dev/null 2>&1
+cfy secrets create openstack_auth_url -s $OS_AUTH_URL
+
+cfy secrets delete openstack_username >/dev/null 2>&1
+cfy secrets create openstack_username -s $OS_USERNAME
+
+cfy secrets delete openstack_password >/dev/null 2>&1
+cfy secrets create openstack_password -s $OS_PASSWORD
+
+cfy secrets delete region >/dev/null 2>&1
+cfy secrets create region -s $OS_REGION_NAME
+
+cfy secrets delete openstack_tenant_name >/dev/null 2>&1
+cfy secrets create openstack_tenant_name -s $OS_TENANT_NAME


### PR DESCRIPTION
The idea is to allow this repo to store supporting files (a script in this case) for documents external to the traditional getcloudify docs), per Ido's suggestion.