### PR TITLE
Installing cluster: postgres uses postgres_ca_cert_path

### DIFF
--- a/content/install_maintain/installation/installing-cluster.md
+++ b/content/install_maintain/installation/installing-cluster.md
@@ -84,8 +84,7 @@ postgresql_server:
 ssl_inputs:
   postgresql_server_cert_path: "<path to server crt file>"
   postgresql_server_key_path: "<path to server key file>"
-
-  ca_cert_path: "<path to CA crt file>"
+  postgresql_ca_cert_path: "<path to CA crt file>"
   
   
 services_to_install:


### PR DESCRIPTION
It doesn't use overall CA path.

This is tested eg. in the cloudify-manager-install's CI, with this DB config:
https://github.com/cloudify-cosmo/cloudify-manager-install/blob/master/.circleci/cluster/db_config.yaml