### PR TITLE
CY-1458 - Improved headers styling and content part scrolling

### DIFF
--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -511,7 +511,6 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
   margin: 0.85rem 0 1.7rem 0;
-  padding: 0.75rem 0 0 0;
   text-rendering: optimizeLegibility; 
   font-family: 'Quicksand', serif; }
 

--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -511,6 +511,7 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
   margin: 0.85rem 0 1.7rem 0;
+  padding: 0.75rem 0 0 0;
   text-rendering: optimizeLegibility; 
   font-family: 'Quicksand', serif; }
 

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -282,7 +282,8 @@ article {
   -webkit-box-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  margin-top: 3.5rem; }
+  margin-top: 3.5rem;
+  overflow: auto; }
 
 article section.page {
   -webkit-box-flex: 1;

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -293,6 +293,12 @@ article section.page {
   margin-left: 20rem;
   overflow-y: auto; 
   padding: 2rem 4rem; }
+  article section.page h2,
+  article section.page h3,
+  article section.page h4,
+  article section.page h5,
+  article section.page h6 {
+    padding: 0.75rem 0 0 0; }
   article section.page h1:first-of-type {
     margin: 2rem 0rem;
     font-family: "Quicksand", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;


### PR DESCRIPTION
# Changes
- scrollbar is attached only to content pane not to the whole site (with header and footer)
- live site: https://docs.cloudify.co/staging/anchored-headers-fix

# Before
![image](https://user-images.githubusercontent.com/5202105/61026003-9755ce80-a3b2-11e9-9da7-acda0de2cf50.png)

# After
![image](https://user-images.githubusercontent.com/5202105/61025991-8a38df80-a3b2-11e9-8bb5-2795bfd85e09.png)
