### PR TITLE
Resume docs: link to operation and workflow pages

### DIFF
--- a/content/working_with/workflows/resuming.md
+++ b/content/working_with/workflows/resuming.md
@@ -17,10 +17,14 @@ When a workflow is resumed, the workflow function is executed again. Workflows w
 
 Most workflows (including all built-in ones) are implemented in terms of a tasks graph. When the workflow is being executed, the state of the tasks graph, and each operation in it, is persisted to storage. When the workflow is resumed, the tasks graph is reconstructed, and the execution continues.
 
+See [Resuming support]({{< relref "working_with/workflows/creating-your-own-workflow.md#resuming-support" >}}) for more information about creating custom workflows that can be resumed.
+
 ### Resumable operations
 
 If the workflow execution was interrupted while executing an operation (which is true in most cases), the operation which was running needs to be resumed as well. If the operation was an agent operation, the Manager will continue waiting for the result, and the workflow will continue.
 If the operation was a Manager-side (management worker) operation, it will be restarted, provided the operation function is declared as resumable. Otherwise, the workflow will fail with an error describing the operation which could not have been retried.
+
+See [Making operations resumable]({{< relref "developer/writing_plugins/creating-your-own-plugin.md#making-operations-resumable" >}}) for more information about creating custom operations that can be resumed.
 
 ### Resuming workflows after a Manager outage
 


### PR DESCRIPTION
This makes the high-level overview of resuming support also link to the
more specific pages about creating operations and workflows that can
support the feature.

Thanks @isaac-s for being the test subject :)