### PR TITLE
Remove Cluster Status widget configuration info

### DIFF
--- a/content/working_with/console/widgets/highAvailability.md
+++ b/content/working_with/console/widgets/highAvailability.md
@@ -28,6 +28,3 @@ Each cluster node is presented with:
 * **ID** - displayed in popup on hovering ID button.
 
 ![cluster-status-widget]( /images/ui/widgets/cluster-status-node-status.png )
-
-#### Widget Settings
-* `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds


### PR DESCRIPTION
After recent change - https://github.com/cloudify-cosmo/cloudify-stage/pull/901 - there is no widget data fetching in Cluster Status widget. Data is fetched from application state and cluster-status is being fetched periodically by the application itself, not the widget.