### PR TITLE
Running manager on docker: add more explanations

### DIFF
--- a/content/install_maintain/installation/manager-image.md
+++ b/content/install_maintain/installation/manager-image.md
@@ -40,10 +40,6 @@ Make sure that your environment meets the [prerequisites]({{< relref "install_ma
         1. To verify that the Cloudify Manager is installed after the instance is created and running, go to the Cloudify Console at `http://<public_ip>`. Use this IP address as the manager IP address for CLI and Cloudify Console connections.
 
     * ##### Docker
-        {{< warning title="For Remote Instances Only" >}}
-        This Docker image is designed to run on a remote instance, not on a docker installation on your local machine.
-        {{< /warning >}}
-
         1. Verify that the target computer meets the [prerequisites]({{< relref "install_maintain/installation/prerequisites.md" >}}).
 
         1. To create and start a Docker container with Cloudify Manager, run:

--- a/content/install_maintain/installation/manager-image.md
+++ b/content/install_maintain/installation/manager-image.md
@@ -41,9 +41,7 @@ Make sure that your environment meets the [prerequisites]({{< relref "install_ma
 
     * ##### Docker
         1. Verify that the target computer meets the [prerequisites]({{< relref "install_maintain/installation/prerequisites.md" >}}).
-
         1. To create and start a Docker container with Cloudify Manager, run:
-
             {{< highlight bash >}}
 docker run --name cfy_manager_local -d --restart unless-stopped \
   -v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /run/lock \
@@ -51,8 +49,32 @@ docker run --name cfy_manager_local -d --restart unless-stopped \
   -p 80:80 -p 5671:5671 -p 53333:53333 \
   cloudifyplatform/premium-cloudify-manager-aio:latest
 {{< /highlight >}}
+          Or, with a minimal command:
+            {{< highlight bash >}}
+docker run -d \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /run/lock \
+  cloudifyplatform/premium-cloudify-manager-aio:latest
+{{< /highlight >}}
+          Explanation of commonly used `docker run` flags:
 
-        1. To verify that the Cloudify Manager is installed after the instance is created and running, go to the Cloudify Console at `http://<host_ip>`. Use this IP address as the manager IP address for CLI and Cloudify Console connections.
+          * `--restart unless-stopped`: auto-restart of the container
+          * `security-opt secconmp:unconfined --cap-add SYS_ADMIN` or alternatively `--privileged`: when running a SystemD-based container, giving the container elevated privileges is required for SystemD itself to run. When using a new enough Docker Engine (at least 17.05+), those flags can be omitted, but the host SELinux policy might need to be adjusted by doing `setsebool -P container_manage_cgroup true`. Neither those flags, nor the SELinux adjustment, are required when using containers not based on SystemD.
+          * `-v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /run/lock`: mounts required only when using a SystemD-based container. Note that the host machine must also be using SystemD.
+          * `-p 80:80 -p 5671:5671 -p 53333:53333` or alternatively `-p 443:443`: the ports 5671 and 53333 are used for manager/agent communication, while the port 80 or 443 is used for CLI/UI access to the manager. Using the `-p` flags, or even `--network host`, those ports can be forwarded from the host machine to the container.
+          * `--name cfy_manager_local`: the name given to the container, for use with later `docker exec` calls.
+          * `-v /some/absolute/path/to/config.yaml:/etc/cloudify/config.yaml:rw`: mounting a yaml file at `/etc/cloudify/config.yaml` allows configuring the manager container, including setting an admin password, and providing paths to TLS certificates.
+        1. The container's starter service will take a while to boot up all the manager components. Run `cfy_manager wait-for-starter` to synchronously wait for the manager to fully start:
+            {{< highlight bash >}}
+docker exec cfy_manager_local cfy_manager wait-for-starter
+{{< /highlight >}}
+        When done, `wait-for-starter` will print out the manager's admin password to stdout.
+
+        1. You can change the admin password by running `cfy_manager reset-admin-password`:
+            {{< highlight bash >}}
+docker exec cfy_manager_local cfy_manager reset-admin-password NEW_PASSWORD
+{{< /highlight >}}
+
+        1. To verify that the Cloudify Manager is installed after the instance is created and running, go to the Cloudify Console at `http://<manager_ip>`, or if the manager's port was bound to the host machine's port using `-p 80:80` or similar, use `http://<host_ip>`. Use this IP address as the manager IP address for CLI and Cloudify Console connections.
 
         1. Cloudify Console's HTTP port depends on actual Cloudify Manager's configuration.  If you wish [to enable SSL]({{< relref "install_maintain/manager_architecture/security.md#ssl-mode-for-external-communication" >}}), you should also start using `443` port (`-p 443:443` in the `docker run` command) and `https://` protocol for accessing Cloudify Console.
 


### PR DESCRIPTION
- drop a useless note
- explain flags to `docker run`
- add an explanation for the used `docker run` flags
- add a note about configuring the manager
- explain how to get/reset credentials