### PR TITLE
Improve documentation version dropdown

### DIFF
--- a/layouts/partials/version.html
+++ b/layouts/partials/version.html
@@ -1,8 +1,7 @@
 <p>
-    <!-- "window.location = " without () -->
     <select onchange="
         var newVersion = this.options[this.selectedIndex].value;
-        window.location = '/' + newVersion;
+        window.location = '/' + newVersion + '{{.Page.RelPermalink}}';
     ">
         <option value="latest">5.1 (Latest)</option>
         <option value="5.0.5">5.0.5</option>


### PR DESCRIPTION
Add current relative URL to new version link on docs version change.
Now, instead of opening main page for the specific version you are redirected to specific version + current page link.