### PR TITLE
RD-1222 Update ui-components version to 2.4.1

### DIFF
--- a/content/developer/writing_widgets/widgets-components.md
+++ b/content/developer/writing_widgets/widgets-components.md
@@ -6,7 +6,7 @@ category: Cloudify Console
 draft: false
 weight: 700
 aliases: ["/apis/widgets-components/", "/developer/custom_console/widgets-components/"]
-ui_components_link: "https://docs.cloudify.co/ui-components/2.3.0"
+ui_components_link: "https://docs.cloudify.co/ui-components/2.4.1"
 ---
 
 You can find here documentation for all [ReactJS](https://reactjs.org/) components developed by the  {{< param product_name >}} team.


### PR DESCRIPTION
The latest version of cloudify-ui-components that will be used by stage is 2.4.1. Here's the updated link to the storybook:

https://docs.cloudify.co/ui-components/2.4.1/