### PR TITLE
RD-1829 Describe incompatibility between Resource Filter and Deployments View

### DIFF
--- a/content/working_with/console/widgets/filter.md
+++ b/content/working_with/console/widgets/filter.md
@@ -14,9 +14,7 @@ By default, the widget allows filtering by blueprint, deployment and execution, 
 It is discouraged to place the Resource Filter widget alongside
 [the Deployments View widget]({{< relref "working_with/console/widgets/deploymentsView.md" >}})
 on the same page.
-
 The Resource Filter widget does not influence the filtering performed in the Deployments View widget.
-
 Moreover, the deployment selection in the Resource Filter widget will most likely be overridden
 by the Deployments View widget.
 {{% /note %}}

--- a/content/working_with/console/widgets/filter.md
+++ b/content/working_with/console/widgets/filter.md
@@ -10,6 +10,16 @@ By default, the widget allows filtering by blueprint, deployment and execution, 
 
 ![resource-filter]( /images/ui/widgets/resource_filter.png )
 
+{{% note %}}
+It is discouraged to place the Resource Filter widget alongside
+[the Deployments View widget]({{< relref "working_with/console/widgets/deploymentsView.md" >}})
+on the same page.
+
+The Resource Filter widget does not influence the filtering performed in the Deployments View widget.
+
+Moreover, the deployment selection in the Resource Filter widget will most likely be overridden
+by the Deployments View widget.
+{{% /note %}}
 
 ## Settings
 


### PR DESCRIPTION
This PR describes the incompatibility between the Resource Filter widget and the Deployments View widget. See the description of RD-1829 for more information about the technical incompatibilities.

There is already a similar note in the description of the Deployments View widget: https://docs.cloudify.co/6.0.0/working_with/console/widgets/deploymentsview/#filtering-deployments

Once this PR is merged, I will update the readme in cloudify-stage in a separate PR

Staging: https://docs.cloudify.co/staging/RD-1829-explain-incompatibility-resource-filter-and-deployments-view/working_with/console/widgets/filter/