### PR TITLE
RD-1787 Upgrade cloudify-ui-components version to 2.5.0

### DIFF
--- a/content/developer/writing_widgets/widgets-components.md
+++ b/content/developer/writing_widgets/widgets-components.md
@@ -6,7 +6,7 @@ category: Cloudify Console
 draft: false
 weight: 700
 aliases: ["/apis/widgets-components/", "/developer/custom_console/widgets-components/"]
-ui_components_link: "https://docs.cloudify.co/ui-components/2.4.7"
+ui_components_link: "https://docs.cloudify.co/ui-components/2.5.0"
 ---
 
 You can find here documentation for all [ReactJS](https://reactjs.org/) components developed by the  {{< param product_name >}} team.


### PR DESCRIPTION
This PR changes the link to point to the latest version of https://github.com/cloudify-cosmo/cloudify-ui-components (released after https://github.com/cloudify-cosmo/cloudify-ui-components/pull/75 was merged)

https://docs.cloudify.co/ui-components/2.5.0