### PR TITLE
RD-2789 Upgrade UI components link to point to 2.6.0

### DIFF
--- a/content/developer/writing_widgets/widgets-components.md
+++ b/content/developer/writing_widgets/widgets-components.md
@@ -6,7 +6,7 @@ category: Cloudify Console
 draft: false
 weight: 700
 aliases: ["/apis/widgets-components/", "/developer/custom_console/widgets-components/"]
-ui_components_link: "https://docs.cloudify.co/ui-components/2.5.0"
+ui_components_link: "https://docs.cloudify.co/ui-components/2.6.0"
 ---
 
 You can find here documentation for all [ReactJS](https://reactjs.org/) components developed by the  {{< param product_name >}} team.


### PR DESCRIPTION
There's a new release of UI components:
https://github.com/cloudify-cosmo/cloudify-ui-components/releases/tag/v2.6.0

https://docs.cloudify.co/ui-components/2.6.0