### PR TITLE
Revert "RD-3330 Updated ui-components version to 2.9.1"

### DIFF
--- a/content/developer/writing_widgets/widgets-components.md
+++ b/content/developer/writing_widgets/widgets-components.md
@@ -6,7 +6,7 @@ category: Cloudify Console
 draft: false
 weight: 700
 aliases: ["/apis/widgets-components/", "/developer/custom_console/widgets-components/"]
-ui_components_link: "https://docs.cloudify.co/ui-components/2.9.1"
+ui_components_link: "https://docs.cloudify.co/ui-components/2.9.0"
 ---
 
 You can find here documentation for all [ReactJS](https://reactjs.org/) components developed by the  {{< param product_name >}} team.


### PR DESCRIPTION
`cloudify-ui-components` v2.9.1 introduced a regression bug.