### PR TITLE
Revert "Update version of cloudify-components to 2.9.2"

### DIFF
--- a/content/developer/writing_widgets/widgets-components.md
+++ b/content/developer/writing_widgets/widgets-components.md
@@ -6,7 +6,7 @@ category: Cloudify Console
 draft: false
 weight: 700
 aliases: ["/apis/widgets-components/", "/developer/custom_console/widgets-components/"]
-ui_components_link: "https://docs.cloudify.co/ui-components/2.9.2"
+ui_components_link: "https://docs.cloudify.co/ui-components/2.9.0"
 ---
 
 You can find here documentation for all [ReactJS](https://reactjs.org/) components developed by the  {{< param product_name >}} team.


### PR DESCRIPTION
Reverts cloudify-cosmo/docs.getcloudify.org#2029 as we need to figure out why there's bundle size increase in `cloudify-stage` coming from `cloudify-ui-components` v2.9.2.