### PR TITLE
RD-3496 Update ui-components-link to v2.9.2

### DIFF
--- a/content/developer/writing_widgets/widgets-components.md
+++ b/content/developer/writing_widgets/widgets-components.md
@@ -6,7 +6,7 @@ category: Cloudify Console
 draft: false
 weight: 700
 aliases: ["/apis/widgets-components/", "/developer/custom_console/widgets-components/"]
-ui_components_link: "https://docs.cloudify.co/ui-components/2.9.0"
+ui_components_link: "https://docs.cloudify.co/ui-components/2.9.2"
 ---
 
 You can find here documentation for all [ReactJS](https://reactjs.org/) components developed by the  {{< param product_name >}} team.


### PR DESCRIPTION
Provides update of `ui-components-link`. The same PR as https://github.com/cloudify-cosmo/docs.getcloudify.org/pull/2029.