### PR TITLE
RD-3477 Removed gramatically incorrect prepending LDAP with 'the'

### DIFF
--- a/content/working_with/console/widgets/userGroups.md
+++ b/content/working_with/console/widgets/userGroups.md
@@ -20,7 +20,7 @@ The widget displays the following information regarding each of the user groups:
 
 * **Name**
 * **LDAP group** When working with an LDAP-based external authentication system, this field identifies the LDAP user group which is connected to the current {{< param product_name >}} user-group.   
-   This column will not be visible if the LDAP is disabled in {{< param product_name >}}.
+   This column will not be visible if LDAP is disabled in {{< param product_name >}}.
 * **Admin** If checked, all users who are members of this groups will have the role of sys-admins on the manager.
 * **# Users** number of users who are members of the group
 * **# Tenants** number of tenants the user-group is assigned with.
@@ -45,7 +45,7 @@ Please notice that by belonging to several groups, users might be assigned to a 
 2. Enter a name for the group.   
    The name must contain at least five alphanumeric characters and begin with a letter. It can also include the following characters: `-`, `_` or `.`.
 3. (Optional) If you want to add user group that is configured in your LDAP/AD system, enter the LDAP Group Distinguished Name (DN). The format must be `CN=GroupName,OU=OUName,DC=Domaincomponent,DC=DomainComponent`, for example `CN=ldapwiki,OU=groups,DC=example,DC=com`.   
-   This field will not be visible if the LDAP is disabled in {{< param product_name >}}.
+   This field will not be visible if LDAP is disabled in {{< param product_name >}}.
 4. Check **Admin** checkbox if you want group members to have administrator privileges.
 5. Click **Add**.
 


### PR DESCRIPTION
This change is related to the discussion which took place [here](https://github.com/cloudify-cosmo/cloudify-stage/pull/1682#discussion_r759250926)

The result of the conversation was that the `LDAP` is incorrectly prepended with the `the` word