### PR TITLE
RD-3983 Set-owner now with -t tenant_name option

### DIFF
--- a/content/cli/orch_cli/blueprints.md
+++ b/content/cli/orch_cli/blueprints.md
@@ -545,6 +545,8 @@ Change ownership of a blueprint.
 
 * `-s, --username USERNAME` - The name of the user who will be the new owner of the
                               resource.  [required]
+* `-t, --tenant-name TEXT`  - The name of the tenant of the secret. If not specified, the current
+                              tenant will be used.
 
 &nbsp;
 #### Example

--- a/content/cli/orch_cli/deployments.md
+++ b/content/cli/orch_cli/deployments.md
@@ -510,6 +510,8 @@ Change ownership of a deployment.
 
 * `-s, --username USERNAME` - The name of the user who will be the new owner of the
                               resource.  [required]
+* `-t, --tenant-name TEXT`  - The name of the tenant of the secret. If not specified, the current
+                              tenant will be used.
 
 &nbsp;
 #### Example

--- a/content/cli/orch_cli/secrets.md
+++ b/content/cli/orch_cli/secrets.md
@@ -293,6 +293,8 @@ Change ownership of a secret.
 
 * `-s, --username USERNAME` - The name of the user who will be the new owner of the
                               resource.  [required]
+* `-t, --tenant-name TEXT`  - The name of the tenant of the secret. If not specified, the current
+                              tenant will be used.
 
 &nbsp;
 #### Example


### PR DESCRIPTION
`cfy blueprints set-owner`, `cfy deployments set-owner`, `cfy secrets set-owner` can be called with optional `-t tenant_name` parameter now.