### PR TITLE
RD-4317 Update writing widgets documentation

### DIFF
--- a/content/developer/writing_widgets/development-methods.md
+++ b/content/developer/writing_widgets/development-methods.md
@@ -21,9 +21,9 @@ about how to use those methods.
 
 ## Building
 
-To ease widget building, you should use one of the following environments:
+To ease widget building, you should use 
+[{{< param cfy_console_name >}} Development Environment](https://github.com/cloudify-cosmo/cloudify-stage). 
 
-1. [Widget Development Environment](https://github.com/cloudify-cosmo/Cloudify-UI-Widget-boilerplate) - it's quick to set it up, but you'll have to upload your widget to the {{< param cfy_manager_name >}} after every code change.
-2. [{{< param cfy_console_name >}} Development Environment](https://github.com/cloudify-cosmo/cloudify-stage) - it takes more time to set it up, but once you have it configured, you won't need to upload your widget to the {{< param cfy_manager_name >}} after every change in widget's code, because building tools running in background would update it for you.  
-
-You can find environment configuration description under above mentioned links.
+Once you setup the project, check **Custom widgets section** in  
+[widgets README file](https://github.com/cloudify-cosmo/cloudify-stage/tree/master/widgets#readme) 
+to learn more about how to create, build and test your widget.   

--- a/content/developer/writing_widgets/development-methods.md
+++ b/content/developer/writing_widgets/development-methods.md
@@ -24,6 +24,6 @@ about how to use those methods.
 To ease widget building, you should use 
 [{{< param cfy_console_name >}} Development Environment](https://github.com/cloudify-cosmo/cloudify-stage). 
 
-Once you setup the project, check **Custom widgets section** in  
+Once you setup the project, check **Custom widgets** section in 
 [widgets README file](https://github.com/cloudify-cosmo/cloudify-stage/tree/master/widgets#readme) 
 to learn more about how to create, build and test your widget.   

--- a/content/developer/writing_widgets/useful-links.md
+++ b/content/developer/writing_widgets/useful-links.md
@@ -8,4 +8,3 @@ weight: 900
 ---
 
 * [{{< param cfy_console_name >}} @ GitHub](https://github.com/cloudify-cosmo/cloudify-stage) - Git repository with {{< param cfy_console_name >}} source code
-* [{{< param cfy_console_name >}} Widgets Boilerplate @ GitHub](https://github.com/cloudify-cosmo/Cloudify-UI-Widget-boilerplate) - Git repository containing widget development environment

--- a/content/developer/writing_widgets/widget-backend.md
+++ b/content/developer/writing_widgets/widget-backend.md
@@ -9,7 +9,9 @@ weight: 500
 
 With widget backend support user can create HTTP endpoints in Console backend. They allow to define specific actions when endpoint is called. There can be used helper services not available in widget frontend.
 
-Example of working widget with backend can be found [here](https://github.com/cloudify-cosmo/Cloudify-UI-Widget-boilerplate/tree/master/widgets/backendWidget).
+Examples of widgets with backend support:
+* [simple test widget](https://github.com/cloudify-cosmo/cloudify-stage/blob/master/test/cypress/fixtures/widgets/testWidgetBackend.zip)
+* [Executions widget](https://github.com/cloudify-cosmo/cloudify-stage/blob/master/widgets/executions)
 
 
 ## Security Aspects

--- a/content/developer/writing_widgets/widget-backend.md
+++ b/content/developer/writing_widgets/widget-backend.md
@@ -10,8 +10,9 @@ weight: 500
 With widget backend support user can create HTTP endpoints in Console backend. They allow to define specific actions when endpoint is called. There can be used helper services not available in widget frontend.
 
 Examples of widgets with backend support:
-* [simple test widget](https://github.com/cloudify-cosmo/cloudify-stage/blob/master/test/cypress/fixtures/widgets/testWidgetBackend.zip)
-* [Executions widget](https://github.com/cloudify-cosmo/cloudify-stage/blob/master/widgets/executions)
+
+* [simple test widget ZIP package](https://github.com/cloudify-cosmo/cloudify-stage/blob/master/test/cypress/fixtures/widgets/testWidgetBackend.zip)
+* [Executions widget source code](https://github.com/cloudify-cosmo/cloudify-stage/blob/master/widgets/executions)
 
 
 ## Security Aspects

--- a/content/working_with/console/customization/edit-mode.md
+++ b/content/working_with/console/customization/edit-mode.md
@@ -68,7 +68,9 @@ You can choose to display Blueprints Catalog widget contents as a table.
 
 ## Adding Widgets
 
-A catalog of widgets is available to enable you to select your preferred data display on any page.
+### Built-in widgets
+
+A catalog of built-in widgets is available to enable you to select your preferred data display on any page.
 
 1. In **Edit Mode**, choose a desired container (or create a new one) and click **Add Widget**.   
    The **Add Widget** button is visible in all containers when you are in **Edit Mode**.  
@@ -81,10 +83,26 @@ A catalog of widgets is available to enable you to select your preferred data di
 Click on widget thumbnail to see it full-sized.
 {{% /tip %}}
 
-The widget appears on the page. You can drag and drop it in the position that you prefer.
+### Custom widgets
+
+To install custom widget:
+
+1. In **Edit Mode**, choose a desired container (or create a new one) and click **Add Widget**.   
+   The **Add Widget** button is visible in all containers when you are in **Edit Mode**.
+2. Click **Install new widget** button.
+3. Provide URL to widget archive or click folder button to select widget archive from your machine and click 
+   **Install** button.
+4. Select newly installed widget from the list and click **Add selected widgets**.
+
+## Adjusting Widgets
+
+In **Edit Mode**, you can drag and drop widgets in the position that you prefer.
 You can resize a widget while holding the resize icon in the lower right corner of the widget.
 
-To delete a widget, click the **X** icon in the top right corner of the widget.
+
+## Deleting Widgets
+
+In **Edit Mode**, to delete a widget, click the **X** icon in the top right corner of the widget.
 
 
 ## Working with tabs containers

--- a/content/working_with/console/widgets/filters.md
+++ b/content/working_with/console/widgets/filters.md
@@ -41,7 +41,8 @@ Add, edit and clone operation modals share a common component for defining filte
 
 The component presents a list of rows, each representing a single filter rule. Each row contains three inputs:
 
-* Rule type selection dropdown - selecting the context of the rule which can be based on labels or supported deployment attributes such as blueprint ID, site name, or creator.
+* Rule type selection dropdown - selecting the context of the rule which can be based on labels or supported 
+  deployment attributes such as blueprint ID, creator, display name, site name or tenant name.
 * Rule operator dropdown. The set of available operators to choose from depends on the selected rule type. See **Table 1.** and **Table 2.** below for details.
 * Value input (for attribute rules) or key/value input(s) (for label rules). 
 
@@ -133,7 +134,7 @@ The component presents a list of rows, each representing a single filter rule. E
       <td>The deployment attribute ends with the specified value.</td>
     </tr>
   </tbody>
-  <caption style="caption-side: bottom; text-align: left"><strong>Table 2.</strong> Attributes (Blueprint, Site name, Creator) operators 
+  <caption style="caption-side: bottom; text-align: left"><strong>Table 2.</strong> Attributes operators 
 mapping</caption>
 </table>
 


### PR DESCRIPTION
As https://github.com/cloudify-cosmo/Cloudify-UI-Widget-boilerplate is not maintained, I removed all references to it.

Improved https://github.com/cloudify-cosmo/cloudify-stage support for widgets development within https://github.com/cloudify-cosmo/cloudify-stage/pull/1845.