### PR TITLE
Compatibility with newer Hugo versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@ You can see it available in the [Cloudify Documentation Center](https://docs.clo
 
 The Cloudify Documentation Center is built with [Hugo]( https://gohugo.io/ ) and is based on the [DocDock]( https://github.com/vjeantet/hugo-theme-docdock.git ) theme.
 
+## Development with Docker
+
+There's several public Docker images shipping Hugo. For development,
+`klakegg/hugo` is the most up-to-date one
+With it, mount the source code in `/src`, and the `hugo server` command will
+run a HTTP server on port 1313.
+
+1. Go to the main directory of this repo
+1. `docker run -it --rm -v $(pwd):/src -p 1313:1313 klakegg/hugo server`
+1. Go to `http://localhost:1313` in your browser
+
+### Faster iteration
+
+Loading the search index takes a long time when refreshing the site in your
+browser. You can skip generating the index, which will make the browser-based
+documentation MUCH faster, but search will be unavailable.
+
+To do so:
+1. Edit `config.toml`
+1. Change `outputs.home` to be just `["HTML", "RSS"]` (without `"JSON"`)
+
+## Development with local Hugo
 To run the Cloudify Documentation Center locally:
 
 1. Install the latest Hugo:

--- a/config.toml
+++ b/config.toml
@@ -101,10 +101,15 @@ docker_install_command_prefix = "docker run --name cfy_manager_local -p 8000:800
 version = "6.4.0"
 
 [markup]
-defaultMarkdownHandler = "blackfriday"
+defaultMarkdownHandler = "goldmark"
+# blackfriday was used up until Cloudify 7.0, but new Hugo versions deprecate it,
+# in favour of goldmark instead. Left for reference in case of any rendering
+# weirdness, feel free to remove this post-7.0.
+#defaultMarkdownHandler = "blackfriday"
 
-[blackfriday]
-hrefTargetBlank = false
+[markup.goldmark.renderer]
+# we have a whole bunch of inline html, which goldmark considers unsafe
+unsafe = true
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]

--- a/content/about/cloudify-manager.md
+++ b/content/about/cloudify-manager.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Cloudify Manager
 category: Introduction
 draft: false

--- a/content/about/doc-info.md
+++ b/content/about/doc-info.md
@@ -1,7 +1,5 @@
 ---
-layout: bt_wiki
 title: Welcome to the Cloudify Documentation Site
-layout: bt_wiki
 title: How this Document is Organized
 category: Introduction
 draft: false

--- a/content/about/what-is-cloudify.md
+++ b/content/about/what-is-cloudify.md
@@ -31,14 +31,14 @@ Built-in Integration with [Jenkins]({{< relref "working_with/integration/jenkins
 
 ### <span style="color:#0077fc">Consistent workflow management across all the infrastructure domains</span>
 
-{{< param product_name >}} uses intent-based modeling (also known as Infrastructure as Code) where users define the desired state of the system rather than the way to get there. {{< param product_name >}} autogenerates the install, uninstall, heal, and scale workflow from that definition a.k.a [implicit workflow] ({{< relref "working_with/workflows/built-in-workflows.md" >}}). {{< param product_name >}} also allows users to define their own custom workflow to interact with the system as part of the day-2 operation. {{< param product_name >}} supports multiple execution methods starting from SSH using Fabric and script as well as using a configuration management platform such as Ansible.
+{{< param product_name >}} uses intent-based modeling (also known as Infrastructure as Code) where users define the desired state of the system rather than the way to get there. {{< param product_name >}} autogenerates the install, uninstall, heal, and scale workflow from that definition a.k.a [implicit workflow]({{< relref "working_with/workflows/built-in-workflows.md" >}}). {{< param product_name >}} also allows users to define their own custom workflow to interact with the system as part of the day-2 operation. {{< param product_name >}} supports multiple execution methods starting from SSH using Fabric and script as well as using a configuration management platform such as Ansible.
 
 ### <span style="color:#0077fc">Operability</span>
 
 {{< param product_name >}} is designed with ease of operation in mind. Enhancing the level of information the user can get while reducing the level of {{< param product_name >}} expertise required to do so.
 The new [{{< param cfy_console_name >}}]({{< relref "working_with/console/" >}})  provides a simple way to navigate through the topology view (Intent) via the actual workflow steps that have been executed on a particular deployment instance. Troubleshooting is made easy via a dependency graph and filtering relevant logs that are associated with a specific step in that workflow.
 
-All this functionality is available also through [Command Line Interface] ({{< relref "cli" >}}) and [REST API] ({{< relref "developer/apis/" >}}).
+All this functionality is available also through [Command Line Interface]({{< relref "cli" >}}) and [REST API]({{< relref "developer/apis/" >}}).
 
 ### <span style="color:#0077fc">Customizable Portal and Catalogue Service</span>
 
@@ -47,7 +47,7 @@ All this functionality is available also through [Command Line Interface] ({{< r
 
 ### <span style="color:#0077fc">Enhanced Security and RBAC support</span>
 
-{{< param product_name >}} provides end [security] ({{< relref "install_maintain/manager_architecture/security">}}) of its internal and external resources.
+{{< param product_name >}} provides end [security]({{< relref "install_maintain/manager_architecture/security">}}) of its internal and external resources.
 This includes support for secret store, encryption of all internal communication channels, as well as multi-tenancy and RBAC support to control who gets access to each of the {{< param product_name >}} managed resources.
 
 ### <span style="color:#0077fc">Blueprint modeling and design using the {{< param cfy_composer_name >}}</span>

--- a/content/about/what-is-cloudify.md
+++ b/content/about/what-is-cloudify.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: What Is Cloudify?
 category: Introduction
 draft: false

--- a/content/bestpractices/vmware_docs.md
+++ b/content/bestpractices/vmware_docs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Cloudify Solution for the VMware stack
 category: Manager Architecture
 draft: false

--- a/content/cli/_index.md
+++ b/content/cli/_index.md
@@ -8,9 +8,9 @@ alwaysopen = false
 {{%children style="h2" description="true"%}}
 
 ## Prerequisites
-The simplest way to get the {{< param cfy_cli_name >}} utility is through the {{< param product_name >}} docker image. See [this guide] ({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}}) to learn more on this option.
+The simplest way to get the {{< param cfy_cli_name >}} utility is through the {{< param product_name >}} docker image. See [this guide]({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}}) to learn more on this option.
 
-To install the {{< param cfy_cli_name >}} utility directly on your Linux, Windows or Mac environment refer to the [CLI installation guide] ({{< relref "install_maintain/installation/installing-cli" >}}).
+To install the {{< param cfy_cli_name >}} utility directly on your Linux, Windows or Mac environment refer to the [CLI installation guide]({{< relref "install_maintain/installation/installing-cli" >}}).
 
 ## Common options
 

--- a/content/cli/cli_flows/create-deployment-flow.md
+++ b/content/cli/cli_flows/create-deployment-flow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment Creation Workflow
 category: Manager Architecture
 draft: false

--- a/content/cli/cli_flows/execute-workflow-flow.md
+++ b/content/cli/cli_flows/execute-workflow-flow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Workflow Execution Flow
 category: Manager Architecture
 draft: false

--- a/content/cli/cli_flows/logs-events-flow.md
+++ b/content/cli/cli_flows/logs-events-flow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Logs and Events Workflow
 category: Manager Architecture
 draft: false

--- a/content/cli/cli_flows/upload-blueprint-flow.md
+++ b/content/cli/cli_flows/upload-blueprint-flow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Upload Blueprint Workflow
 category: Manager Architecture
 draft: false

--- a/content/cli/maint_cli/certificates.md
+++ b/content/cli/maint_cli/certificates.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: certificates
 category: Docs
 draft: false

--- a/content/cli/maint_cli/clusters.md
+++ b/content/cli/maint_cli/clusters.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: cluster
 category: Docs
 draft: false

--- a/content/cli/maint_cli/config.md
+++ b/content/cli/maint_cli/config.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: config
 category: Docs
 draft: false

--- a/content/cli/maint_cli/init.md
+++ b/content/cli/maint_cli/init.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: init
 category: Docs
 draft: false

--- a/content/cli/maint_cli/ldap.md
+++ b/content/cli/maint_cli/ldap.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: ldap
 category: Docs
 draft: false

--- a/content/cli/maint_cli/license.md
+++ b/content/cli/maint_cli/license.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: license
 category: Docs
 draft: false

--- a/content/cli/maint_cli/profiles.md
+++ b/content/cli/maint_cli/profiles.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: profiles
 category: Docs
 draft: false

--- a/content/cli/maint_cli/sites.md
+++ b/content/cli/maint_cli/sites.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: sites
 category: Docs
 draft: false

--- a/content/cli/maint_cli/snapshots.md
+++ b/content/cli/maint_cli/snapshots.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: snapshots
 category: Docs
 draft: false

--- a/content/cli/maint_cli/ssh.md
+++ b/content/cli/maint_cli/ssh.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: ssh
 category: Docs
 draft: false

--- a/content/cli/maint_cli/tenants.md
+++ b/content/cli/maint_cli/tenants.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: tenants
 category: Docs
 draft: false

--- a/content/cli/maint_cli/use.md
+++ b/content/cli/maint_cli/use.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: use
 category: Docs
 draft: true

--- a/content/cli/maint_cli/usergroups.md
+++ b/content/cli/maint_cli/usergroups.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: user-groups
 category: Docs
 draft: false

--- a/content/cli/maint_cli/users.md
+++ b/content/cli/maint_cli/users.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: users
 category: Docs
 draft: false

--- a/content/cli/orch_cli/agents.md
+++ b/content/cli/orch_cli/agents.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: agents
 category: Docs
 draft: false

--- a/content/cli/orch_cli/apply.md
+++ b/content/cli/orch_cli/apply.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: apply
 category: Docs
 draft: false

--- a/content/cli/orch_cli/blueprints.md
+++ b/content/cli/orch_cli/blueprints.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: blueprints
 category: Docs
 draft: false

--- a/content/cli/orch_cli/deployments.md
+++ b/content/cli/orch_cli/deployments.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: deployments
 category: Docs
 draft: false

--- a/content/cli/orch_cli/events.md
+++ b/content/cli/orch_cli/events.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: events
 category: Docs
 draft: false

--- a/content/cli/orch_cli/executions.md
+++ b/content/cli/orch_cli/executions.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: executions
 category: Docs
 draft: false

--- a/content/cli/orch_cli/filter-rules.md
+++ b/content/cli/orch_cli/filter-rules.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: filter-rules
 category: Docs
 draft: false

--- a/content/cli/orch_cli/groups.md
+++ b/content/cli/orch_cli/groups.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: groups
 category: Docs
 draft: false

--- a/content/cli/orch_cli/install.md
+++ b/content/cli/orch_cli/install.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: install
 category: Docs
 draft: false

--- a/content/cli/orch_cli/logs.md
+++ b/content/cli/orch_cli/logs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: logs
 category: Docs
 draft: false

--- a/content/cli/orch_cli/maintenance-mode.md
+++ b/content/cli/orch_cli/maintenance-mode.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: maintenance-mode
 category: Docs
 draft: false

--- a/content/cli/orch_cli/node-instances.md
+++ b/content/cli/orch_cli/node-instances.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: node-instances
 category: Docs
 draft: false

--- a/content/cli/orch_cli/nodes.md
+++ b/content/cli/orch_cli/nodes.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: nodes
 category: Docs
 draft: false

--- a/content/cli/orch_cli/plugins.md
+++ b/content/cli/orch_cli/plugins.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: plugins
 category: Docs
 draft: false

--- a/content/cli/orch_cli/secrets.md
+++ b/content/cli/orch_cli/secrets.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: secrets
 category: Docs
 draft: false

--- a/content/cli/orch_cli/status.md
+++ b/content/cli/orch_cli/status.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: status
 category: Docs
 draft: false

--- a/content/cli/orch_cli/tokens.md
+++ b/content/cli/orch_cli/tokens.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: tokens
 category: Docs
 draft: false

--- a/content/cli/orch_cli/uninstall.md
+++ b/content/cli/orch_cli/uninstall.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: uninstall
 category: Docs
 draft: false

--- a/content/cli/orch_cli/workflows.md
+++ b/content/cli/orch_cli/workflows.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: workflows
 category: Docs
 draft: false

--- a/content/developer/apis/rest-client-python.md
+++ b/content/developer/apis/rest-client-python.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Python Client
 category: APIs
 draft: false

--- a/content/developer/blueprints/built-in-types.md
+++ b/content/developer/blueprints/built-in-types.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Built-in Node Types
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/how-to-scale-blueprint.md
+++ b/content/developer/blueprints/how-to-scale-blueprint.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Walkthrough - Create a scaling Blueprint
 category: Blueprints
 draft: true

--- a/content/developer/blueprints/import-resolver.md
+++ b/content/developer/blueprints/import-resolver.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Import Resolver
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/multiple-instances.md
+++ b/content/developer/blueprints/multiple-instances.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Multiple Instances (Scaling)
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-blueprint-labels.md
+++ b/content/developer/blueprints/spec-blueprint-labels.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprint Labels
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-capabilities.md
+++ b/content/developer/blueprints/spec-capabilities.md
@@ -59,7 +59,7 @@ You can view the capabilities either by using the [CLI]({{< relref "cli/orch_cli
 {{< highlight  bash  >}}
 cfy deployments capabilities DEPLOYMENT_ID
 {{< /highlight >}}
-or using it in a blueprint with [get_capability] ({{< relref "spec-intrinsic-functions.md" >}}) intrinsic function 
+or using it in a blueprint with [get_capability]({{< relref "spec-intrinsic-functions.md" >}}) intrinsic function
 or by making a REST call
 {{< highlight  bash  >}}
 curl -X GET --header "Tenant: <manager-tenant>" -u <manager-username>:<manager-password> "http://<manager-ip>/api/v3.1/deployments/<deployment-id>/capabilities"

--- a/content/developer/blueprints/spec-capabilities.md
+++ b/content/developer/blueprints/spec-capabilities.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Capabilities
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-data-types.md
+++ b/content/developer/blueprints/spec-data-types.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Data Types
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-deployment-settings.md
+++ b/content/developer/blueprints/spec-deployment-settings.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment Settings
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-dsl-definitions.md
+++ b/content/developer/blueprints/spec-dsl-definitions.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: DSL Definitions
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-groups.md
+++ b/content/developer/blueprints/spec-groups.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Groups
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-imports.md
+++ b/content/developer/blueprints/spec-imports.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Imports
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-inputs.md
+++ b/content/developer/blueprints/spec-inputs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Inputs
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-interfaces.md
+++ b/content/developer/blueprints/spec-interfaces.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Interfaces
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-intrinsic-functions.md
+++ b/content/developer/blueprints/spec-intrinsic-functions.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Intrinsic Functions
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-labels.md
+++ b/content/developer/blueprints/spec-labels.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Labels
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-node-templates.md
+++ b/content/developer/blueprints/spec-node-templates.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Node Templates
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-node-types.md
+++ b/content/developer/blueprints/spec-node-types.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Node Types
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-outputs.md
+++ b/content/developer/blueprints/spec-outputs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Outputs
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-plugins.md
+++ b/content/developer/blueprints/spec-plugins.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 uid: plugins section
 title: Plugins
 category: Blueprints

--- a/content/developer/blueprints/spec-policies.md
+++ b/content/developer/blueprints/spec-policies.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Policies
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-policy-triggers.md
+++ b/content/developer/blueprints/spec-policy-triggers.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Policy Triggers
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-policy-types.md
+++ b/content/developer/blueprints/spec-policy-types.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Policy Types
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-relationships.md
+++ b/content/developer/blueprints/spec-relationships.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Relationships
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-secretstore.md
+++ b/content/developer/blueprints/spec-secretstore.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Secrets Store
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-upload-resources.md
+++ b/content/developer/blueprints/spec-upload-resources.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 uid: workflows section
 title: Upload Resources
 category: Blueprints

--- a/content/developer/blueprints/spec-versioning.md
+++ b/content/developer/blueprints/spec-versioning.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Versioning
 category: Blueprints
 draft: false

--- a/content/developer/blueprints/spec-workflows.md
+++ b/content/developer/blueprints/spec-workflows.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 uid: workflows section
 title: Workflows
 category: Blueprints

--- a/content/developer/composer/blueprint-creation.md
+++ b/content/developer/composer/blueprint-creation.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Creating Blueprints
 category: Composer
 description: The section coveres all you need for blueprint creation, topology, node types, Adding and editing nodes etc.

--- a/content/developer/composer/customization.md
+++ b/content/developer/composer/customization.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Customization
 description: Resources on how to customize the UI
 category: Composer

--- a/content/developer/composer/features.md
+++ b/content/developer/composer/features.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Features
 description: Describes on how to import and work with nodes
 category: Composer

--- a/content/developer/composer/getting-started.md
+++ b/content/developer/composer/getting-started.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Getting started
 category: Composer
 description: Overview how to access the composer

--- a/content/developer/composer/managing-inputs-outputs.md
+++ b/content/developer/composer/managing-inputs-outputs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Managing Inputs, Outputs and Capabilities
 description: Overview on how to work with inputs, outputs and capabilities 
 category: Composer

--- a/content/developer/composer/managing-plugins.md
+++ b/content/developer/composer/managing-plugins.md
@@ -1,11 +1,10 @@
 ---
-layout: bt_wiki
 title: Managing Plugins
 description: Overview on how to add/remove plugins
 category: Composer
 draft: false
 weight: 550
-------
+---
 
 {{< param cfy_composer_name >}} enables you to add plugins to the Blueprint under the **Plugins** node.
 

--- a/content/developer/composer/managing-resources.md
+++ b/content/developer/composer/managing-resources.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Managing Resources
 description: Explanation on how adding external resource to the bluerpint
 category: Composer

--- a/content/developer/ide_autocomplete.md
+++ b/content/developer/ide_autocomplete.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: IDE Auto Completion
 weight: 80
 ---

--- a/content/developer/writing_plugins/container-support.md
+++ b/content/developer/writing_plugins/container-support.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: A Guide To Cloudify Container Support For Kubernetes And Docker
 category: Writing Plugins
 draft: false

--- a/content/developer/writing_plugins/creating-your-own-plugin.md
+++ b/content/developer/writing_plugins/creating-your-own-plugin.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Writing Your Own Plugin
 category: Writing Plugins
 draft: false

--- a/content/developer/writing_plugins/how-to-work-with-cm.md
+++ b/content/developer/writing_plugins/how-to-work-with-cm.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Integrating Cloudify with Configuration Management Tools
 category: Writing Plugins
 draft: false

--- a/content/developer/writing_plugins/packaging-your-plugin.md
+++ b/content/developer/writing_plugins/packaging-your-plugin.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Creating Wagons
 category: Writing Plugins
 draft: false

--- a/content/developer/writing_widgets/development-methods.md
+++ b/content/developer/writing_widgets/development-methods.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Widget Development Methods
 description: Different development methods available for widget creation.
 category: Cloudify Console

--- a/content/developer/writing_widgets/faq.md
+++ b/content/developer/writing_widgets/faq.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: FAQs
 description: Frequently Asked Questions on widget development.
 category: Cloudify Console

--- a/content/developer/writing_widgets/useful-links.md
+++ b/content/developer/writing_widgets/useful-links.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Useful Links
 description: Resources helpful during widget development.
 category: Cloudify Console

--- a/content/developer/writing_widgets/widget-apis.md
+++ b/content/developer/writing_widgets/widget-apis.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Widget APIs
 description: Description of APIs exposed for widget development.
 category: Cloudify Console

--- a/content/developer/writing_widgets/widget-backend.md
+++ b/content/developer/writing_widgets/widget-backend.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Widget Backend
 description: Description of Widget Backend feature.
 category: Cloudify Console

--- a/content/developer/writing_widgets/widget-definition.md
+++ b/content/developer/writing_widgets/widget-definition.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Widget Definition
 description: Description of widget definition including all available configuration parameters.
 category: Cloudify Console

--- a/content/developer/writing_widgets/widget-structure.md
+++ b/content/developer/writing_widgets/widget-structure.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Widget Structure
 description: Description of widget definition and directory structure.
 category: Cloudify Console

--- a/content/developer/writing_widgets/widgets-components.md
+++ b/content/developer/writing_widgets/widgets-components.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Widget Components Reference
 description: Documentation for all ReactJS components developed by Cloudify team.
 category: Cloudify Console

--- a/content/install_maintain/installation/certificates.md
+++ b/content/install_maintain/installation/certificates.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Certificates Overview
 description: Go over the Cloudify certificates setup.   
 category: Installation

--- a/content/install_maintain/installation/cfy-cluster-manager.md
+++ b/content/install_maintain/installation/cfy-cluster-manager.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Cloudify Cluster Manager
 description: Using the Cloudify Cluster Manager Package
 category: Installation

--- a/content/install_maintain/installation/helm-chart/_index.md
+++ b/content/install_maintain/installation/helm-chart/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deploying a Cloudify Manager to Kubernetes
 description: Deploy a Cloudify Manager to Kubernetes with a helm chart.
 category: Installation

--- a/content/install_maintain/installation/helm-chart/installing-helm-aio.md
+++ b/content/install_maintain/installation/helm-chart/installing-helm-aio.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deploying a Cloudify Manager All In One to Kubernetes
 description: Deploy a Cloudify Manager AIO to Kubernetes with a helm chart.
 category: Installation

--- a/content/install_maintain/installation/helm-chart/installing-helm-aks.md
+++ b/content/install_maintain/installation/helm-chart/installing-helm-aks.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deploying a Cloudify Manager Worker to AKS with helm chart
 description: Deployment to Azure (AKS) of Highly Available Cloudify manager worker using the helm chart.
 category: Installation

--- a/content/install_maintain/installation/helm-chart/installing-helm-eks.md
+++ b/content/install_maintain/installation/helm-chart/installing-helm-eks.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deploying a Cloudify Manager Worker to EKS with helm chart
 description: Deployment to AWS (EKS) of Highly Available Cloudify manager worker using the helm chart.
 category: Installation

--- a/content/install_maintain/installation/helm-chart/installing-helm-gke.md
+++ b/content/install_maintain/installation/helm-chart/installing-helm-gke.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deploying a Cloudify Manager Worker to GKE with helm chart
 description: Deployment to Google (GKE) of Highly Available Cloudify manager worker using the helm chart.
 category: Installation

--- a/content/install_maintain/installation/helm-chart/installing-helm-worker.md
+++ b/content/install_maintain/installation/helm-chart/installing-helm-worker.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deploying a Cloudify Manager Worker to Kubernetes
 description: Deploy a Cloudify Manager Worker to Kubernetes with a helm chart.
 category: Installation

--- a/content/install_maintain/installation/installation-modes.md
+++ b/content/install_maintain/installation/installation-modes.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Understanding the Cloudify platform deployment modes
 description: Understanding the Cloudify platform deployment modes.
 category: Installation

--- a/content/install_maintain/installation/installation-modes.md
+++ b/content/install_maintain/installation/installation-modes.md
@@ -37,7 +37,7 @@ To learn more about installing the Compact Cluster please continue to:
 * [Compact cluster installation guide]({{< relref "install_maintain/installation/three-nodes-cluster" >}})
 
 {{% note %}}  
-Note! The above mentioned page will guide you how to manually deploy a Compact cluster. {{< param product_name >}} provides an automated flow that simplifies the deployment over three existing VMs. To use the Cluster Manager package and automate the cluster deployment flow read: [Cluster Manager package] ({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
+Note! The above mentioned page will guide you how to manually deploy a Compact cluster. {{< param product_name >}} provides an automated flow that simplifies the deployment over three existing VMs. To use the Cluster Manager package and automate the cluster deployment flow read: [Cluster Manager package]({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
 {{% /note %}}
 
 
@@ -53,5 +53,5 @@ To learn more about installing the {{< param product_name >}} fully distributed 
 * [Distributed Cluster with External Database and Messaging queue]({{< relref "install_maintain/installation/installing-external-db-and-queue-cluster" >}})
 
 {{% note %}}  
-Note! The above mentioned page will guide you how to manually deploy a {{< param product_name >}} cluster. {{< param product_name >}} provides an automated flow that simplifies the deployment over three existing VMs. To use the Cluster Manager package and automate the cluster deployment flow read: [Cluster Manager package] ({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
+Note! The above mentioned page will guide you how to manually deploy a {{< param product_name >}} cluster. {{< param product_name >}} provides an automated flow that simplifies the deployment over three existing VMs. To use the Cluster Manager package and automate the cluster deployment flow read: [Cluster Manager package]({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
 {{% /note %}}

--- a/content/install_maintain/installation/installing-cli.md
+++ b/content/install_maintain/installation/installing-cli.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Command Line Interface (CLI) Installation
 description: Communicate with your Cloudify Manager installation using Cloudify CLI.
 category: Installation

--- a/content/install_maintain/installation/installing-cluster.md
+++ b/content/install_maintain/installation/installing-cluster.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Installing a Fully Distributed Cluster
 description: Install a Cloudify Manager Cluster environment to ensure High Availability.
 category: Installation

--- a/content/install_maintain/installation/installing-cluster.md
+++ b/content/install_maintain/installation/installing-cluster.md
@@ -35,16 +35,16 @@ Each of those services is accompanied by a customized monitoring service.  The s
 
 {{% note %}}  
 Before you start the manual process of installing a {{< param product_name >}} cluster, you might want to consider
-using the [Cluster Manager package] ({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
+using the [Cluster Manager package]({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
 that automates it.
 {{% /note %}}  
 
 
 This guide describes the process of configuring and installing such a cluster:
 
-1. [Certificates Setup] ({{< relref "install_maintain/installation/installing-cluster.md#certificates-setup" >}})
-1. [Installing Services] ({{< relref "install_maintain/installation/installing-cluster.md#installing-services" >}})
-1. [Post Installation] ({{< relref "install_maintain/installation/installing-cluster.md#post-installation" >}})
+1. [Certificates Setup]({{< relref "install_maintain/installation/installing-cluster.md#certificates-setup" >}})
+1. [Installing Services]({{< relref "install_maintain/installation/installing-cluster.md#installing-services" >}})
+1. [Post Installation]({{< relref "install_maintain/installation/installing-cluster.md#post-installation" >}})
 
 {{% note title="Externally hosted PostgreSQL and RabbitMQ" %}}  
 In case you use an Externally hosted PostgreSQL or RabbitMQ, i.e. "bring your own", please make sure you go over all sections and
@@ -52,7 +52,7 @@ read the relevant information for this case.
 {{% /note %}}  
 
 **Note:** Before you proceed, make sure that all the required VMs are spinning, that they are all allocated with a public-IP, and that they are configured according
-to the [prerequisites guide] ({{< relref "install_maintain/installation/prerequisites.md" >}}).
+to the [prerequisites guide]({{< relref "install_maintain/installation/prerequisites.md" >}}).
 If you use {{< param product_name >}} best-practice, you would need 9 VMs + a load balancer. The VMs partitioning is 3 PostgreSQL nodes, 3 RabbitMQ nodes, and 3 {{< param cfy_manager_name >}} service nodes.
 
 
@@ -65,10 +65,10 @@ Each of these services is a cluster comprised of three nodes and each node shoul
 Another optional service of the {{< param cfy_manager_name >}} cluster is the Management Service Load Balancer, which should be installed after all the other components.  
 The following sections describe how to install and configure {{< param cfy_manager_name >}} cluster services. The order of installation should be as follows:
 
-1. [PostgresSQL Database Cluster ] ({{< relref "install_maintain/installation/installing-cluster.md#postgresql-database-cluster" >}})  
-2. [RabbitMQ Cluster] ({{< relref "install_maintain/installation/installing-cluster.md#rabbitmq-cluster" >}})  
-3. [{{< param product_name >}} Management Service] ({{< relref "install_maintain/installation/installing-cluster.md#cloudify-management-service" >}})
-4. [Management Service Load Balancer] ({{< relref "install_maintain/installation/installing-cluster.md#management-service-load-balancer" >}})
+1. [PostgresSQL Database Cluster ]({{< relref "install_maintain/installation/installing-cluster.md#postgresql-database-cluster" >}})
+2. [RabbitMQ Cluster]({{< relref "install_maintain/installation/installing-cluster.md#rabbitmq-cluster" >}})
+3. [{{< param product_name >}} Management Service]({{< relref "install_maintain/installation/installing-cluster.md#cloudify-management-service" >}})
+4. [Management Service Load Balancer]({{< relref "install_maintain/installation/installing-cluster.md#management-service-load-balancer" >}})
 
 ### Preperation
 1. Ensure you have nine VMs with cfy_manager available on each(means, curl manager rpm and perform `sudo yum install <Cloudify RPM>`).

--- a/content/install_maintain/installation/installing-external-db-and-queue-cluster.md
+++ b/content/install_maintain/installation/installing-external-db-and-queue-cluster.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Distributed Cluster with External Database and Messaging Queue
 description: Install and Configure External DB And RabbitMQ within Distributed Cluster .
 category: Installation

--- a/content/install_maintain/installation/installing-manager.md
+++ b/content/install_maintain/installation/installing-manager.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Installing and Configuring a Cloudify Manager
 description: Install a single All-In-One Cloudify Manager.
 category: Installation

--- a/content/install_maintain/installation/installing-manager.md
+++ b/content/install_maintain/installation/installing-manager.md
@@ -30,9 +30,9 @@ You can install the [{{< param cfy_cli_name >}}]({{< relref "install_maintain/in
     ```
     sudo yum install <RPM file path>
     ```
-1. Customize [{{< param cfy_manager_name >}}'s settings] ({{< relref "install_maintain/installation/installing-manager.md#cloudify-manager-configuration" >}}).
-1. {{< param product_name >}} License can applied [before installation] ({{< relref "install_maintain/installation/installing-manager.md#cloudify-manager-configuration" >}}) or [after installation] ({{< relref "install_maintain/installation/manager-license" >}})
-1. Install on a single [All-In-One] ({{< relref "install_maintain/installation/installing-manager.md#all-in-one-installation" >}}) host or [install {{< param product_name >}} cluster] ({{< relref "install_maintain/installation/installing-cluster.md" >}})
+1. Customize [{{< param cfy_manager_name >}}'s settings]({{< relref "install_maintain/installation/installing-manager.md#cloudify-manager-configuration" >}}).
+1. {{< param product_name >}} License can applied [before installation]({{< relref "install_maintain/installation/installing-manager.md#cloudify-manager-configuration" >}}) or [after installation]({{< relref "install_maintain/installation/manager-license" >}})
+1. Install on a single [All-In-One]({{< relref "install_maintain/installation/installing-manager.md#all-in-one-installation" >}}) host or [install {{< param product_name >}} cluster]({{< relref "install_maintain/installation/installing-cluster.md" >}})
 1. {{< param cfy_manager_name >}} is ready for use at `http(s)://<manager_public_address>`
 
 
@@ -144,7 +144,7 @@ To install {{< param cfy_manager_name >}}, run:
 
 
 {{% note title="Prerequisites" %}}
-The arguments are optional if already configured in `config.yaml` (see [{{< param cfy_manager_name >}}'s settings] ({{< relref "install_maintain/installation/installing-manager.md#cloudify-manager-configuration" >}}))
+The arguments are optional if already configured in `config.yaml` (see [{{< param cfy_manager_name >}}'s settings]({{< relref "install_maintain/installation/installing-manager.md#cloudify-manager-configuration" >}}))
 {{% /note %}}
 
 

--- a/content/install_maintain/installation/integrating-with-environments.md
+++ b/content/install_maintain/installation/integrating-with-environments.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Integrating with Environments and Tools
 description: Integrate Cloudify with external environments using built-in or custom user-created plugins. Such plugins include - AWS, GCP, OpenStack, vSphere, Kubernetes, and more...
 category: Installation

--- a/content/install_maintain/installation/manager-image.md
+++ b/content/install_maintain/installation/manager-image.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deploying a Cloudify Manager Image
 description: On your preferred cloud provider, deploy a Cloudify Manager from an image.
 category: Installation

--- a/content/install_maintain/installation/manager-license.md
+++ b/content/install_maintain/installation/manager-license.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Activating Cloudify Manager and License Management
 description: Learn how to activate a Cloudify Premium/Spire license and activate it.
 category: Installation

--- a/content/install_maintain/installation/prerequisites.md
+++ b/content/install_maintain/installation/prerequisites.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Prerequisites and Sizing Guidelines for Installing a Cloudify Manager
 description: Before you install Cloudify Manager, please review the following Cloudify manager prerequisites.
 category: Installation

--- a/content/install_maintain/installation/reinstalling-manager.md
+++ b/content/install_maintain/installation/reinstalling-manager.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Reinstalling and Migrating Cloudify Manager
 category: Installation
 draft: true

--- a/content/install_maintain/installation/three-nodes-cluster.md
+++ b/content/install_maintain/installation/three-nodes-cluster.md
@@ -37,7 +37,7 @@ That means that all the managers will be communicating with the active database 
 
 {{% note %}}  
 Before you start the manual process of installing a {{< param product_name >}} cluster, you might want to consider
-using the [Cluster Manager package] ({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
+using the [Cluster Manager package]({{< relref "install_maintain/installation/cfy-cluster-manager.md" >}})
 that automates it.
 {{% /note %}}
 

--- a/content/install_maintain/installation/three-nodes-cluster.md
+++ b/content/install_maintain/installation/three-nodes-cluster.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Compact cluster
 description: Cloudify Compact high availability cluster (3 nodes configuration)
 category: Installation

--- a/content/install_maintain/manager_architecture/components.md
+++ b/content/install_maintain/manager_architecture/components.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Overview of the Open Source Components in Cloudify
 category: Manager Architecture
 draft: false

--- a/content/install_maintain/manager_architecture/security.md
+++ b/content/install_maintain/manager_architecture/security.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Security
 category: Manager Architecture
 draft: false

--- a/content/trial_getting_started/set_trial_manager/download_community.md
+++ b/content/trial_getting_started/set_trial_manager/download_community.md
@@ -41,7 +41,7 @@ ____
 
 What's next?
 
-* To manage your installation using the command line utility on your docker image refer to the [local CLI guide] ({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}})
-* To run your first hello world example on your local manager refer to the **[local hello world example] ({{< relref "trial_getting_started/examples/local/local_hello_world_example" >}})** (no cloud credentials needed)
+* To manage your installation using the command line utility on your docker image refer to the [local CLI guide]({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}})
+* To run your first hello world example on your local manager refer to the **[local hello world example]({{< relref "trial_getting_started/examples/local/local_hello_world_example" >}})** (no cloud credentials needed)
 * To run your first multi cloud examples on AWS, Azure, GCP and OpenStack using the native {{< param product_name >}} plugins as well as Cloud Formation, Azure ARM and Ansible plugins refer to the  **[example based tutorials]({{< relref "trial_getting_started/examples/_index.md" >}})**.
 * To run your first Kubernetes service on OpenShift, KubeSpray, GKE, EKS or AKS refer to the  [Kubernetes reference guide ]({{< relref "working_with/official_plugins/orchestration/kubernetes" >}}).

--- a/content/trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli.md
+++ b/content/trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli.md
@@ -8,13 +8,13 @@ docker_image_name = "cloudifyplatform/community-cloudify-manager-aio:latest"
 
 {{%children style="h2" description="true"%}}
 
-The {{< param product_name >}} Docker image comes with [{{< param cfy_cli_name >}}] ({{< relref "cli/" >}}) pre installed.
+The {{< param product_name >}} Docker image comes with [{{< param cfy_cli_name >}}]({{< relref "cli/" >}}) pre installed.
 This guide illustrates how to use {{< param product_name >}} docker image as local CLI client.
 
 ## Install local Docker image
 
 Install {{< param product_name >}} on your local desktop.
-Use the [following steps] ({{< relref "trial_getting_started/set_trial_manager/download_community" >}}) to install {{< param product_name >}} docker image on your local desktop.
+Use the [following steps]({{< relref "trial_getting_started/set_trial_manager/download_community" >}}) to install {{< param product_name >}} docker image on your local desktop.
 
 For example:
 
@@ -87,4 +87,4 @@ This example deploys an http deamon on on your docker instance. (The example doe
 
 See the [command line reference guide]({{< relref "cli/" >}}) to learn how to deploy a new service, execute workflow, etc..
 
-For more options on how to install the {{< param cfy_cli_name >}} on Linux, Windows or Mac refer to the [CLI installation guide] ({{< relref "install_maintain/installation/installing-cli" >}}).
+For more options on how to install the {{< param cfy_cli_name >}} on Linux, Windows or Mac refer to the [CLI installation guide]({{< relref "install_maintain/installation/installing-cli" >}}).

--- a/content/trial_getting_started/set_trial_manager/hosted_trial.md
+++ b/content/trial_getting_started/set_trial_manager/hosted_trial.md
@@ -64,4 +64,4 @@ What's next?
 
 * To run your first multi cloud examples on AWS, Azure, GCP and OpenStack using the native {{< param product_name >}} plugins as well as Cloud Formation, Azure ARM and Ansible plugins refer to the  **[example based tutorials]({{< relref "trial_getting_started/examples/_index.md" >}})**.
 * To run your first Kubernetes service on OpenShift, KubeSpray, GKE, EKS or AKS refer to the  [Kubernetes reference guide ]({{< relref "working_with/official_plugins/orchestration/kubernetes" >}}).
-* Optional: To manage your installation using the command line utility refer to the [local CLI guide] ({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}})
+* Optional: To manage your installation using the command line utility refer to the [local CLI guide]({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}})

--- a/content/trial_getting_started/set_trial_manager/trial_install.md
+++ b/content/trial_getting_started/set_trial_manager/trial_install.md
@@ -50,7 +50,7 @@ ____
 
 What's next?
 
-* To manage your installation using the command line utility on your docker image refer to the [local CLI guide] ({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}})
-* To run your first hello world example on your local manager refer to the **[local hello world example] ({{< relref "trial_getting_started/examples/local/local_hello_world_example" >}})** (no cloud credentials needed)
+* To manage your installation using the command line utility on your docker image refer to the [local CLI guide]({{< relref "trial_getting_started/set_trial_manager/getting-started-with-cloudify-docker-and-cli" >}})
+* To run your first hello world example on your local manager refer to the **[local hello world example]({{< relref "trial_getting_started/examples/local/local_hello_world_example" >}})** (no cloud credentials needed)
 * To run your first multi cloud examples on AWS, Azure, GCP and OpenStack using the native {{< param product_name >}} plugins as well as Cloud Formation, Azure ARM and Ansible plugins refer to the  **[example based tutorials]({{< relref "trial_getting_started/examples/_index.md" >}})**.
 * To run your first Kubernetes service on OpenShift, KubeSpray, GKE, EKS or AKS refer to the  [Kubernetes reference guide ]({{< relref "working_with/official_plugins/orchestration/kubernetes" >}}).

--- a/content/working_with/console/customization/edit-mode.md
+++ b/content/working_with/console/customization/edit-mode.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Edit Mode
 category: Console
 draft: false

--- a/content/working_with/console/customization/overrides.md
+++ b/content/working_with/console/customization/overrides.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Labels Overrides
 category: Console
 draft: false

--- a/content/working_with/console/customization/templates-mgmt.md
+++ b/content/working_with/console/customization/templates-mgmt.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Templates Management
 category: Console
 draft: false

--- a/content/working_with/console/customization/user-configuration.md
+++ b/content/working_with/console/customization/user-configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: User Configuration
 category: Console
 draft: false

--- a/content/working_with/console/pages/agents-page.md
+++ b/content/working_with/console/pages/agents-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Agents Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/blueprints-page.md
+++ b/content/working_with/console/pages/blueprints-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprints Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/dashboard-page.md
+++ b/content/working_with/console/pages/dashboard-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Dashboard Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/environments-page.md
+++ b/content/working_with/console/pages/environments-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Environments Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/executions-page.md
+++ b/content/working_with/console/pages/executions-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Executions Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/filters-page.md
+++ b/content/working_with/console/pages/filters-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Filters Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/groups-page.md
+++ b/content/working_with/console/pages/groups-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Groups Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/logs-page.md
+++ b/content/working_with/console/pages/logs-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Logs Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/plugins-page.md
+++ b/content/working_with/console/pages/plugins-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Plugins Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/secrets-page.md
+++ b/content/working_with/console/pages/secrets-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Secrets Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/services-page.md
+++ b/content/working_with/console/pages/services-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Services Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/sites-page.md
+++ b/content/working_with/console/pages/sites-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Sites Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/snapshots-page.md
+++ b/content/working_with/console/pages/snapshots-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Snapshots Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/system-health-page.md
+++ b/content/working_with/console/pages/system-health-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: System Health Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/tenants-page.md
+++ b/content/working_with/console/pages/tenants-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Tenants Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/tokens-page.md
+++ b/content/working_with/console/pages/tokens-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Tokens Page
 category: Console
 draft: false

--- a/content/working_with/console/pages/users-page.md
+++ b/content/working_with/console/pages/users-page.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Users Page
 category: Console
 draft: false

--- a/content/working_with/console/widgets/_index.md
+++ b/content/working_with/console/widgets/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Widgets
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/agents.md
+++ b/content/working_with/console/widgets/agents.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Agents Management
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/blueprintActionButtons.md
+++ b/content/working_with/console/widgets/blueprintActionButtons.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprint Action Buttons
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/blueprintCatalog.md
+++ b/content/working_with/console/widgets/blueprintCatalog.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprints Catalog
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/blueprintInfo.md
+++ b/content/working_with/console/widgets/blueprintInfo.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprint Info
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/blueprintNum.md
+++ b/content/working_with/console/widgets/blueprintNum.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Number of blueprints
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/blueprintSources.md
+++ b/content/working_with/console/widgets/blueprintSources.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprint Sources
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/blueprintUploadButton.md
+++ b/content/working_with/console/widgets/blueprintUploadButton.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprint upload button
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/blueprints.md
+++ b/content/working_with/console/widgets/blueprints.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprints
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/buttonLink.md
+++ b/content/working_with/console/widgets/buttonLink.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Button link
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/cloudNum.md
+++ b/content/working_with/console/widgets/cloudNum.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Number of clouds
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/composerLink.md
+++ b/content/working_with/console/widgets/composerLink.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Composer link
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deploymentActionButtons.md
+++ b/content/working_with/console/widgets/deploymentActionButtons.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment action buttons
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deploymentButton.md
+++ b/content/working_with/console/widgets/deploymentButton.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Create deployment button
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deploymentInfo.md
+++ b/content/working_with/console/widgets/deploymentInfo.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment Info
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deploymentNum.md
+++ b/content/working_with/console/widgets/deploymentNum.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Number of deployments
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deploymentWizardButtons.md
+++ b/content/working_with/console/widgets/deploymentWizardButtons.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment wizard buttons
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deployments.md
+++ b/content/working_with/console/widgets/deployments.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Blueprint deployments
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deploymentsView.md
+++ b/content/working_with/console/widgets/deploymentsView.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployments View
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/deploymentsViewDrilledDown.md
+++ b/content/working_with/console/widgets/deploymentsViewDrilledDown.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployments View (drilled-down)
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/events.md
+++ b/content/working_with/console/widgets/events.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Events and Logs
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/eventsFilter.md
+++ b/content/working_with/console/widgets/eventsFilter.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Events and Logs Filter
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/executionNum.md
+++ b/content/working_with/console/widgets/executionNum.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Number of running executions
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/executions.md
+++ b/content/working_with/console/widgets/executions.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Executions
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/executionsStatus.md
+++ b/content/working_with/console/widgets/executionsStatus.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Executions Statuses Graph
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/filter.md
+++ b/content/working_with/console/widgets/filter.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Resource Filter
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/filters.md
+++ b/content/working_with/console/widgets/filters.md
@@ -1,6 +1,5 @@
 
 ---
-layout: bt_wiki
 title: Filters
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/highAvailability.md
+++ b/content/working_with/console/widgets/highAvailability.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Cluster Status
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/inputs.md
+++ b/content/working_with/console/widgets/inputs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment Inputs
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/labels.md
+++ b/content/working_with/console/widgets/labels.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Labels
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/maintenanceModeButton.md
+++ b/content/working_with/console/widgets/maintenanceModeButton.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Maintenance Mode button
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/managers.md
+++ b/content/working_with/console/widgets/managers.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Spire Manager
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/nodes.md
+++ b/content/working_with/console/widgets/nodes.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Nodes List
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/nodesComputeNum.md
+++ b/content/working_with/console/widgets/nodesComputeNum.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Number of compute nodes
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/nodesStats.md
+++ b/content/working_with/console/widgets/nodesStats.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Nodes Statistics
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/onlyMyResources.md
+++ b/content/working_with/console/widgets/onlyMyResources.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Only my resources
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/outputs.md
+++ b/content/working_with/console/widgets/outputs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment Outputs/Capabilities
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/pluginUploadButton.md
+++ b/content/working_with/console/widgets/pluginUploadButton.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Plugin upload button
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/plugins.md
+++ b/content/working_with/console/widgets/plugins.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Plugins List
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/pluginsCatalog.md
+++ b/content/working_with/console/widgets/pluginsCatalog.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Plugins Catalog
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/pluginsNum.md
+++ b/content/working_with/console/widgets/pluginsNum.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Number of plugins
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/secrets.md
+++ b/content/working_with/console/widgets/secrets.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Secrets Store Management
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/serversNum.md
+++ b/content/working_with/console/widgets/serversNum.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Number of nodes
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/serviceButton.md
+++ b/content/working_with/console/widgets/serviceButton.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Service button
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/sites.md
+++ b/content/working_with/console/widgets/sites.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Sites
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/sitesMap.md
+++ b/content/working_with/console/widgets/sitesMap.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Sites Map
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/snapshots.md
+++ b/content/working_with/console/widgets/snapshots.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Snapshots List
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/tenants.md
+++ b/content/working_with/console/widgets/tenants.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Tenant Management
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/text.md
+++ b/content/working_with/console/widgets/text.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Text
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/tokens.md
+++ b/content/working_with/console/widgets/tokens.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Tokens
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/topology.md
+++ b/content/working_with/console/widgets/topology.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Topology
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/userGroups.md
+++ b/content/working_with/console/widgets/userGroups.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: User Group Management
 category: Widgets
 draft: false

--- a/content/working_with/console/widgets/userManagement.md
+++ b/content/working_with/console/widgets/userManagement.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: User Management
 category: Widgets
 draft: false

--- a/content/working_with/manager/actionable-events.md
+++ b/content/working_with/manager/actionable-events.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Actionable Events (Hooks)
 category: Manager
 draft: false

--- a/content/working_with/manager/broker-security.md
+++ b/content/working_with/manager/broker-security.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Broker Security (RabbitMQ)
 category: Manager
 draft: false

--- a/content/working_with/manager/create-deployment.md
+++ b/content/working_with/manager/create-deployment.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Creating a Deployment
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/delete-blueprint.md
+++ b/content/working_with/manager/delete-blueprint.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deleting a Blueprint
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/delete-deployment.md
+++ b/content/working_with/manager/delete-deployment.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deleting a Deployment
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/execute-workflow.md
+++ b/content/working_with/manager/execute-workflow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Executing Workflows
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/execute-workflow.md
+++ b/content/working_with/manager/execute-workflow.md
@@ -11,7 +11,7 @@ workflows_link: workflows-built-in.html
 
 After you have [created a deployment]({{< relref "working_with/manager/create-deployment.md" >}}), you must execute the process that will implement your application's actual manifestation in your selected environment.
 
-This process is achieved using the [install workflow] ({{< relref "working_with/workflows/built-in-workflows.md#the-install-workflow" >}}), which is the default workflow provided by {{< param product_name >}} for deploying your application.
+This process is achieved using the [install workflow]({{< relref "working_with/workflows/built-in-workflows.md#the-install-workflow" >}}), which is the default workflow provided by {{< param product_name >}} for deploying your application.
 
 You can create workflows for different types of actions such as deploying code, changing the infrastructure state, and even for overriding the default Install Workflow.
 

--- a/content/working_with/manager/external-authentication.md
+++ b/content/working_with/manager/external-authentication.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: External Authentication
 draft: false
 weight: 1550

--- a/content/working_with/manager/high-availability-clusters.md
+++ b/content/working_with/manager/high-availability-clusters.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Using Clusters to Provide High Availability
 category: Manager
 draft: false

--- a/content/working_with/manager/implement-multi-tenancy.md
+++ b/content/working_with/manager/implement-multi-tenancy.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Configuring Multi-Tenancy
 category: Manager
 draft: false

--- a/content/working_with/manager/ldap-integration.md
+++ b/content/working_with/manager/ldap-integration.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Integrating with LDAP
 draft: false
 weight: 1450

--- a/content/working_with/manager/maintenance-mode.md
+++ b/content/working_with/manager/maintenance-mode.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Maintenance Mode
 category: Manager
 draft: false

--- a/content/working_with/manager/okta_authentication.md
+++ b/content/working_with/manager/okta_authentication.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Okta Authentication
 category: Manager
 draft: false

--- a/content/working_with/manager/packaging-blueprints.md
+++ b/content/working_with/manager/packaging-blueprints.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Packaging a Blueprint
 category: Blueprints
 draft: false

--- a/content/working_with/manager/resource-visibility.md
+++ b/content/working_with/manager/resource-visibility.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Resource Visibility
 category: Manager
 draft: false

--- a/content/working_with/manager/roles-management.md
+++ b/content/working_with/manager/roles-management.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Managing Roles
 category: Manager
 draft: false

--- a/content/working_with/manager/service-logs.md
+++ b/content/working_with/manager/service-logs.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Service Logs
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/share-blueprint.md
+++ b/content/working_with/manager/share-blueprint.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Sharing a Blueprint
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/snapshots.md
+++ b/content/working_with/manager/snapshots.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Snapshots
 category: Manager
 draft: false

--- a/content/working_with/manager/update-deployment.md
+++ b/content/working_with/manager/update-deployment.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Updating a Deployment
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/upload-blueprint.md
+++ b/content/working_with/manager/upload-blueprint.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Uploading a Blueprint
 category: Manager Intro
 draft: false

--- a/content/working_with/manager/user-management.md
+++ b/content/working_with/manager/user-management.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Managing Users
 description: Cloudify provides a user management mechanism, so you can define different users with different permissions, and upon login perform authentication and authorization to control the users’ access to resources.
 category: Manager

--- a/content/working_with/manager/using-secrets.md
+++ b/content/working_with/manager/using-secrets.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Using the Secrets Store
 category: Manager
 draft: false

--- a/content/working_with/official_plugins/Configuration/_index.md
+++ b/content/working_with/official_plugins/Configuration/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Configuration Plugins
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Configuration/ansible.md
+++ b/content/working_with/official_plugins/Configuration/ansible.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Ansible Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Configuration/diamond.md
+++ b/content/working_with/official_plugins/Configuration/diamond.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Diamond Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Configuration/fabric.md
+++ b/content/working_with/official_plugins/Configuration/fabric.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Fabric (SSH) Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Configuration/netconf.md
+++ b/content/working_with/official_plugins/Configuration/netconf.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Netconf Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Configuration/script.md
+++ b/content/working_with/official_plugins/Configuration/script.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Script Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/_index.md
+++ b/content/working_with/official_plugins/Infrastructure/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Infrastructure Plugins
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/aws.md
+++ b/content/working_with/official_plugins/Infrastructure/aws.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: AWS Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/aws.md
+++ b/content/working_with/official_plugins/Infrastructure/aws.md
@@ -2216,7 +2216,7 @@ For more information, and possible keyword arguments, see: [Autoscaling:create_a
 
   * `cloudify.interfaces.lifecycle.create`: Store `resource_config` in runtime properties.
   * `cloudify.interfaces.lifecycle.configure`: Executes the [CreateAutoScalingGroup](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_CreateAutoScalingGroup.html) action.
-  * `cloudify.interfaces.lifecycle.stop`: Stops all instances associated with auto scaling group before removing them [UpdateAutoScalingGroup] (https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_UpdateAutoScalingGroup.html) action.
+  * `cloudify.interfaces.lifecycle.stop`: Stops all instances associated with auto scaling group before removing them [UpdateAutoScalingGroup](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_UpdateAutoScalingGroup.html) action.
   * `cloudify.interfaces.lifecycle.delete`: Executes the [DeleteAutoScalingGroup](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DeleteAutoScalingGroup.html) action.
 
 **Relationships**

--- a/content/working_with/official_plugins/Infrastructure/azure.md
+++ b/content/working_with/official_plugins/Infrastructure/azure.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Azure Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/gcp.md
+++ b/content/working_with/official_plugins/Infrastructure/gcp.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Google Cloud Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/host-pool.md
+++ b/content/working_with/official_plugins/Infrastructure/host-pool.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Host-Pool Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/nsx-t.md
+++ b/content/working_with/official_plugins/Infrastructure/nsx-t.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: NSX-T Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/openstack.md
+++ b/content/working_with/official_plugins/Infrastructure/openstack.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: OpenStack Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/openstackv3.md
+++ b/content/working_with/official_plugins/Infrastructure/openstackv3.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Openstack Plugin v3
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/openstackv3.md
+++ b/content/working_with/official_plugins/Infrastructure/openstackv3.md
@@ -2144,7 +2144,7 @@ This node type refers to an Openstack Router.
   * `cloudify.interfaces.lifecycle.create`: Executes [create_router](https://developer.openstack.org/api-ref/network/v2/#create-router).
   * `cloudify.interfaces.lifecycle.delete`: Executes [create_router](https://developer.openstack.org/api-ref/network/v2/#delete-router).
   * `cloudify.interfaces.lifecycle.start`:
-      - Add static routes to router table by executing [update_router] (https://developer.openstack.org/api-ref/network/v2/#update-router).
+      - Add static routes to router table by executing [update_router](https://developer.openstack.org/api-ref/network/v2/#update-router).
       - Inputs:
           - `routes`: _List_. _required_. List of routes accepted by the update Router API method
   * `cloudify.interfaces.lifecycle.stop`: Remove static routes from router table by executing [update_router](https://developer.openstack.org/api-ref/network/v2/#update-router).

--- a/content/working_with/official_plugins/Infrastructure/starlingx.md
+++ b/content/working_with/official_plugins/Infrastructure/starlingx.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: StarlingX Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/vcloud.md
+++ b/content/working_with/official_plugins/Infrastructure/vcloud.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: vCloud Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Infrastructure/vsphere.md
+++ b/content/working_with/official_plugins/Infrastructure/vsphere.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: vSphere Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Orchestration/_index.md
+++ b/content/working_with/official_plugins/Orchestration/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Orchestration Plugins
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Orchestration/docker.md
+++ b/content/working_with/official_plugins/Orchestration/docker.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Docker Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Orchestration/helm.md
+++ b/content/working_with/official_plugins/Orchestration/helm.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Helm 3 Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Orchestration/kubernetes.md
+++ b/content/working_with/official_plugins/Orchestration/kubernetes.md
@@ -605,7 +605,7 @@ The kubernetes plugin works with EKS, AKS, GKE.
 
 ## EKS cluster
 
-On blueprint examples repository, there is an example of [deploying an EKS cluster.] (https://github.com/cloudify-community/blueprint-examples/blob/master/kubernetes/aws-eks/README.md)
+On blueprint examples repository, there is an example of [deploying an EKS cluster.](https://github.com/cloudify-community/blueprint-examples/blob/master/kubernetes/aws-eks/README.md)
 
 this example demonstrates a deployment of eks cluster with one node group.
 We will explain how we used the AWS plugin alongside kubernetes plugin on this example in order to deploy the cluster.
@@ -665,7 +665,7 @@ And now,using the kubernetes plugin it creates resources in the cluster like pod
 
 ## GKE cluster
 
-On examples repository, there is an example of [deploying GKE cluster.] (https://github.com/cloudify-community/blueprint-examples/blob/master/kubernetes/gcp-gke/blueprint.yaml)
+On examples repository, there is an example of [deploying GKE cluster.](https://github.com/cloudify-community/blueprint-examples/blob/master/kubernetes/gcp-gke/blueprint.yaml)
 
 This example demonstrates a deployment of kubernetes cluster consists of one node pool(with 2 nodes) and one pod.
 
@@ -713,7 +713,7 @@ Then, with the same credentials it creates a pod.
 
 ## AKS cluster
 
-On blueprints examples repository, there is an example of [deploying an AKS cluster.] (https://github.com/cloudify-community/blueprint-examples/blob/master/kubernetes/azure-aks/blueprint.yaml)
+On blueprints examples repository, there is an example of [deploying an AKS cluster.](https://github.com/cloudify-community/blueprint-examples/blob/master/kubernetes/azure-aks/blueprint.yaml)
 
 This example demonstrates a deployment of aks cluster with one node pool and three nodes inside the nodepool.
 In order to deploy the cluster, Azure plugin alongside kubernetes plugin used.

--- a/content/working_with/official_plugins/Orchestration/kubernetes.md
+++ b/content/working_with/official_plugins/Orchestration/kubernetes.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Kubernetes Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Orchestration/terraform.md
+++ b/content/working_with/official_plugins/Orchestration/terraform.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Terraform Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/_index.md
+++ b/content/working_with/official_plugins/Utilities/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Utilities Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/cloudinit.md
+++ b/content/working_with/official_plugins/Utilities/cloudinit.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Cloud Init Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/configuration.md
+++ b/content/working_with/official_plugins/Utilities/configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Configuration Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/custom-workflow.md
+++ b/content/working_with/official_plugins/Utilities/custom-workflow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Custom workflow Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/deploymentproxy.md
+++ b/content/working_with/official_plugins/Utilities/deploymentproxy.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Deployment Proxy
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/files.md
+++ b/content/working_with/official_plugins/Utilities/files.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: File Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/ftp.md
+++ b/content/working_with/official_plugins/Utilities/ftp.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: FTP Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/hooks-workflow.md
+++ b/content/working_with/official_plugins/Utilities/hooks-workflow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Hooks Workflow Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/key.md
+++ b/content/working_with/official_plugins/Utilities/key.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: SSH Key Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/rest.md
+++ b/content/working_with/official_plugins/Utilities/rest.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: REST Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/rollback.md
+++ b/content/working_with/official_plugins/Utilities/rollback.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Rollback Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/scalelist.md
+++ b/content/working_with/official_plugins/Utilities/scalelist.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Scalelist Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/secrets.md
+++ b/content/working_with/official_plugins/Utilities/secrets.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Secrets Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/suspend.md
+++ b/content/working_with/official_plugins/Utilities/suspend.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Suspend Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/official_plugins/Utilities/terminal.md
+++ b/content/working_with/official_plugins/Utilities/terminal.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Terminal Plugin
 category: Official Plugins
 draft: false

--- a/content/working_with/service_composition/component.md
+++ b/content/working_with/service_composition/component.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Component Node Type
 category: Service Composition
 draft: false

--- a/content/working_with/service_composition/shared-resource.md
+++ b/content/working_with/service_composition/shared-resource.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: SharedResource Node Type
 category: Service Composition
 draft: false

--- a/content/working_with/workflows/built-in-workflows.md
+++ b/content/working_with/workflows/built-in-workflows.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Built-in Workflows
 category: Workflows
 draft: false

--- a/content/working_with/workflows/cancelling-execution.md
+++ b/content/working_with/workflows/cancelling-execution.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Cancelling Workflow Executions
 category: Workflows
 draft: false

--- a/content/working_with/workflows/creating-your-own-workflow.md
+++ b/content/working_with/workflows/creating-your-own-workflow.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Creating Custom Workflows
 category: Workflows
 draft: false

--- a/content/working_with/workflows/dry-run.md
+++ b/content/working_with/workflows/dry-run.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Dry Run Workflow Execution
 category: Workflows
 draft: false

--- a/content/working_with/workflows/error-handling.md
+++ b/content/working_with/workflows/error-handling.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Workflow Error Handling
 category: Workflows
 draft: false

--- a/content/working_with/workflows/parameters.md
+++ b/content/working_with/workflows/parameters.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Workflow and Execution Parameters
 category: Workflows
 draft: false

--- a/content/working_with/workflows/resuming.md
+++ b/content/working_with/workflows/resuming.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Resuming workflow execution
 category: Workflows
 draft: false

--- a/content/working_with/workflows/statuses.md
+++ b/content/working_with/workflows/statuses.md
@@ -1,5 +1,4 @@
 ---
-layout: bt_wiki
 title: Workflow Execution Statuses
 category: Workflows
 draft: false

--- a/layouts/partials/flex/head.html
+++ b/layouts/partials/flex/head.html
@@ -8,7 +8,7 @@
       <meta name="description" content="{{ .Description }}">
       {{ end }}
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-      {{ .Hugo.Generator }}
+      {{ hugo.Generator }}
       <title>{{ .Title }} | {{ .Site.Title }}</title>
       <link rel="shortcut icon" href="{{"images/favicon.png" | relURL}}" type="image/x-icon" />
       <link href="{{"css/font-awesome.min.css" | relURL}}" rel="stylesheet">

--- a/layouts/partials/flex/selectnavigation.html
+++ b/layouts/partials/flex/selectnavigation.html
@@ -15,7 +15,7 @@
 {{- $level := .level }}
  {{- with .sect}}
   {{- if .IsSection}}
-    <option value="{{ .Permalink}}" {{if eq .URL $currentNode.URL}} selected{{end}}>
+    <option value="{{ .Permalink}}" {{if eq .Permalink $currentNode.Permalink}} selected{{end}}>
   {{if gt $level 1 }}
     {{- range after 1 (seq $level)}}-{{ end }} 
   {{end}} {{.Title}}</option>
@@ -50,7 +50,7 @@
   {{end}}
   {{- else}}
     {{- if not .Params.Hidden }}
-      <option value="{{ .Permalink}}" {{if eq .URL $currentNode.URL}} selected{{end}}> 
+      <option value="{{ .Permalink}}" {{if eq .Permalink $currentNode.Permalink}} selected{{end}}>
 {{- range after 1 (seq $level)}}-{{ end }} {{.Title}}</option>
     {{- end}}
   {{- end}}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -42,8 +42,7 @@
 {{ define "childs" }}
 	{{- range .menu }}
 		{{- if and .Params.hidden (not $.showhidden) }}
-		{{- else}}
-
+		{{- else -}}
 <span>
 {{- if hasPrefix $.style "h"}}
 	{{- $num := sub ( int (trim $.style "h") ) 1 }}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -50,17 +50,13 @@
 	{{- $numn := add $num $.count }}
 
 	{{- (printf "<h%d>" $numn)|safeHTML}}
-		<a href="{{.URL}}" >{{ .Title }}</a>
+		<a href="{{.RelPermalink}}" >{{ .Title }}</a>
 	{{- (printf "</h%d>" $numn)|safeHTML}}
 {{- else}}
 	{{- (printf "<%s>" $.style)|safeHTML}}
-		<a href="{{.URL}}" >{{ .Title }}</a>
+		<a href="{{.RelPermalink}}" >{{ .Title }}</a>
 	{{- (printf "</%s>" $.style)|safeHTML}}
 {{- end}}
-
-
-
-
 
 			{{- if $.description}}
 				{{- if .Description}}

--- a/themes/docdock/layouts/partials/menu.html
+++ b/themes/docdock/layouts/partials/menu.html
@@ -19,9 +19,9 @@
   {{- if and .IsSection (or (not .Params.hidden) $.showhidden)}}
     {{- $numberOfPages := (add (len .Pages) (len .Sections)) }}
     {{- safeHTML .Params.head}}
-    <li data-nav-id="{{.URL}}" class="dd-item
+    <li data-nav-id="{{ .RelPermalink }}" class="dd-item
         {{- if .IsAncestor $currentNode}} parent{{end}}
-        {{- if eq .URL $currentNode.URL}} active{{end}}
+        {{- if eq .Permalink $currentNode.Permalink}} active{{end}}
         {{- if .Params.alwaysopen}} alwaysopen{{end -}}
         {{- if ne $numberOfPages 0 }} haschildren{{end}}
         ">
@@ -66,8 +66,8 @@
     </li>
   {{- else}}
     {{- if not .Params.Hidden }}
-      <li data-nav-id="{{.URL}}" class="dd-item
-     {{- if eq .URL $currentNode.URL}} active{{end -}}
+      <li data-nav-id="{{.RelPermalink}}" class="dd-item
+     {{- if eq .Permalink $currentNode.Permalink}} active{{end -}}
       ">
         <div>
           <a href="{{ .RelPermalink}}">

--- a/themes/docdock/layouts/partials/next-prev-page.html
+++ b/themes/docdock/layouts/partials/next-prev-page.html
@@ -7,7 +7,7 @@
 {{- define "menu-nextprev" -}}
     {{- $currentNode := .currentnode -}}
     {{- if ne .menu.Params.hidden true -}}
-        {{- if hasPrefix $currentNode.URL .menu.URL -}}
+        {{- if hasPrefix $currentNode.Permalink .menu.Permalink -}}
             {{- $currentNode.Scratch.Set "NextPageOK" "OK" -}}
             {{- $currentNode.Scratch.Set "prevPage" ($currentNode.Scratch.Get "prevPageTmp") -}}
         {{- else -}}
@@ -35,10 +35,10 @@
     
 {{- if not $.Site.Params.disableNavChevron -}}
     {{- with ($.Scratch.Get "prevPage") -}}
-        <a class="nav nav-prev" href="{{.URL}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i><label>{{.Title}}</label></a>
+        <a class="nav nav-prev" href="{{.RelPermalink}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i><label>{{.Title}}</label></a>
     {{ end -}}
     {{- with ($.Scratch.Get "nextPage") -}}
-        <a class="nav nav-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><label>{{.Title}}</label><i class="fa fa-chevron-right"></i></a>
+        <a class="nav nav-next" href="{{.RelPermalink}}" title="{{.Title}}" style="margin-right: 0px;"><label>{{.Title}}</label><i class="fa fa-chevron-right"></i></a>
     {{- end }}
 {{- end -}}
 </div>

--- a/themes/docdock/layouts/shortcodes/relref.html
+++ b/themes/docdock/layouts/shortcodes/relref.html
@@ -7,7 +7,7 @@
 	{{- end -}}
 {{- else -}}
 	{{- with .Site.GetPage "section" (.Get 0) }}
-		{{- .URL -}}
+		{{- .RelPermalink -}}
 	{{- else -}}
 		{{- .Get 0 | relref .Page -}}
 	{{- end -}}


### PR DESCRIPTION
The first commit of this PR touches every single template,
so I suggest reading the commits separately!

1. Remove `layout: bt_wiki` from all files. This layout doesn't exist, I don't know what it does, and new Hugo versions consider it an error, because it doesn't exist.
2. Replace deprecated `.URL` with `.Permalink`
3. Replace deprecated `.Hugo.Generator` with `hugo.Generator`
4. Switch the markdown renderer from deprecated blackfriday, to the supported goldmark
5. Add a note about dockerized development to readme. It's much better!
6. Fixed links around the codebase to be correct syntax (see [markdown reference](https://commonmark.org/help/))