### PR TITLE
RD-5831 plugin properties and properties_description DSL change

### DIFF
--- a/content/developer/blueprints/spec-plugins.md
+++ b/content/developer/blueprints/spec-plugins.md
@@ -27,18 +27,20 @@ plugins:
 
 # Schema
 
-Keyname              |   Required  | Type        | Description
------------          | --------    | ----        | -----------
-executor             | yes         | string      | Where to execute the plugin's operations. Valid Values: `central_deployment_agent`, `host_agent`. See [Plugin Executor](#executor)
-source               | conditional | string      | From where to retrieve the plugin. May be either a path relative to the `plugins` directory inside the blueprint's root directory, or a URL. If `install` is `false`, `source` is redundant. If `install` is true, `source` (or `package_name`) is mandatory. See [Source Plugins](#source-plugins)
-install_arguments    | no          | string      | Optional arguments passed to the 'pip install' command created for the plugin installation.
-install              | no          | boolean     | Whether to install the plugin, as it might already be installed as part of the agent. Defaults to `true`. (Supported since: cloudify_dsl_1_1)
-package_name         | conditional | string      | Managed plugin package name. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2) If `install` is `false`, `package_name` is redundant. If `install` is true, `package_name` (or `source`) is mandatory.
-package_version      | no          | string      | Managed plugin package version. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)
-supported_platform   | no          | string      | Managed plugin supported platform (e.g. `linux_x86_64`). See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)
-distribution         | no          | string      | Managed plugin distribution. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)
-distribution_version | no          | string      | Managed plugin distribution version. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)
-distribution_release | no          | string      | Managed plugin distribution release. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)
+| Keyname                | Required    | Type       | Description                                                                                                                                                                                                                                                                                         |
+|------------------------|-------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| executor               | yes         | string     | Where to execute the plugin's operations. Valid Values: `central_deployment_agent`, `host_agent`. See [Plugin Executor](#executor)                                                                                                                                                                  |
+| source                 | conditional | string     | From where to retrieve the plugin. May be either a path relative to the `plugins` directory inside the blueprint's root directory, or a URL. If `install` is `false`, `source` is redundant. If `install` is true, `source` (or `package_name`) is mandatory. See [Source Plugins](#source-plugins) |
+| install_arguments      | no          | string     | Optional arguments passed to the 'pip install' command created for the plugin installation.                                                                                                                                                                                                         |
+| install                | no          | boolean    | Whether to install the plugin, as it might already be installed as part of the agent. Defaults to `true`. (Supported since: cloudify_dsl_1_1)                                                                                                                                                       |
+| package_name           | conditional | string     | Managed plugin package name. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2) If `install` is `false`, `package_name` is redundant. If `install` is true, `package_name` (or `source`) is mandatory.                                                                    |
+| package_version        | no          | string     | Managed plugin package version. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)                                                                                                                                                                                        |
+| supported_platform     | no          | string     | Managed plugin supported platform (e.g. `linux_x86_64`). See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)                                                                                                                                                               |
+| distribution           | no          | string     | Managed plugin distribution. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)                                                                                                                                                                                           |
+| distribution_version   | no          | string     | Managed plugin distribution version. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)                                                                                                                                                                                   |
+| distribution_release   | no          | string     | Managed plugin distribution release. See [Managed Plugins](#managed-plugins). (Supported since: cloudify_dsl_1_2)                                                                                                                                                                                   |
+| properties_description | no          | string     | An optional description for the plugin's properties. (Supported since: cloudify_dsl_1_5)                                                                                                                                                                                                            |
+| properties             | no          | dictionary | A dictionary of [plugin's properties](#property-schema). (Supported since: cloudify_dsl_1_5)                                                                                                                                                                                                        |
 
 <br>
 
@@ -69,6 +71,13 @@ Learn more about using the {{< param product_name >}} plugin API [here]({{< relr
 in which case the plugin is installed on the central deployment agent, and `host_agent`, in which case the plugin is installed on the compute node that contains
 the node that maps an operation to the plugin. To override the `executor` configuration on a per-operation basis, see [operation executor]({{< relref "developer/blueprints/spec-interfaces.md#overriding-the-executor" >}}).
 
+## Property Schema
+
+| Keyname        | Required | Type   | Description                                                         |
+|----------------|----------|--------|---------------------------------------------------------------------|
+| type           | no       | string | The required data type of credential's property.                    |
+| description    | no       | string | An optional description for the property.                           |
+| display_label  | no       | string | Used in UI instead of the property's name to describe the property. |
 
 # Examples
 
@@ -165,4 +174,33 @@ node_templates:
     interfaces:
       my_interface:
         start: plugin_with_args.withargs_plugin_package.operations.start
+{{< /highlight >}}
+
+## Plugin Properties
+
+{{< highlight  yaml >}}
+
+tosca_definitions_version: cloudify_dsl_1_5
+
+plugins:
+  plugin_with_properties:
+    executor: central_deployment_agent
+    source: http://www.example.com/path/to/plugin.tar.gz
+    properties_description: |
+      Description regarding the credentials and
+      the link to AWS documentation how to generate
+      or the link to cloudify documentation on
+      different types of authentication methods
+    properties:
+      aws_access_key_id:
+        type: string
+        description: This is a AWS Access Key ID
+        display_label: AWS Access Key ID
+      aws_secret_access_key:
+        type: string
+        description: This is a AWS Secret Access Key
+        display_label: AWS Secret Access Key
+      aws_region:
+        type: string
+        display_label: AWS Region
 {{< /highlight >}}


### PR DESCRIPTION
Document the `credentials` DSL node, introduced in Cloudify DSL 1.5