### PR TITLE
RD-5992 New deployment-update docs (#2369)

### DIFF
--- a/content/cli/orch_cli/deployments.md
+++ b/content/cli/orch_cli/deployments.md
@@ -100,9 +100,7 @@ Update a specified deployment according to the specified blueprint.
 *  `-r, --reinstall-list TEXT` - Node instances IDs to reinstall. This argument can
                         be used multiple times.
 *  `--ignore-failure` - Pass ignore-failure option to uninstall workflow.
-*  `--install-first` - First run the install workflow and then run the uninstall workflow.
 *  `--preview` - If set, does not perform the update and returns the steps this update would make.
-*  `--dont-update-plugins` - If set, does not perform any of the plugin updates.
 *  `-f, --force` -      Force an update to run, in the event that a previous
                         update on this deployment did not complete successfully.
 *  `--include-logs / --no-logs` - Include logs in returned events [default: `True`]
@@ -122,6 +120,9 @@ Update a specified deployment according to the specified blueprint.
                                     statuses. `terminated` executions will be mapped to `successful`
                                     updates, while `failed` and any `*cancel*` statuses will be
                                     mapped to `failed`.
+*  `--drift-only` - Run update without changing anything. This will still check drift and run update operations as necessary.
+* `--skip-drift-check` - Skip running check_drift during deployment update
+* `--skip-heal` - Skip running heal and check_status before the update
 
 For more information, see [deployment update process]({{< relref "working_with/manager/update-deployment.md" >}}).
 

--- a/content/working_with/manager/update-deployment.md
+++ b/content/working_with/manager/update-deployment.md
@@ -7,39 +7,61 @@ weight: 650
 aliases: /manager/update-deployment/
 ---
 
-With {{< param product_name >}}, you can update a deployment. For example, if you have a sizable, complex deployment of webservers and databases, and you need to add a new type of database that must be connected to some of the existing webservers, you would update your deployment. _Updating_ a deployment means that, instead of creating a new deployment from a blueprint to add the new nodes, you add and connect them in your existing deployment, while retaining the state of your current settings.
-
-* A _deployment update blueprint_ is a blueprint that contains the requested state of the deployment after the update. It is a normal and valid blueprint, that can be used to create new deployments as well, like any other blueprint on the manager. Since version 4.4, the blueprint is not uploaded specifically for the update, like in older versions. Instead, a blueprint that is already on the manager is used (passed by blueprint id).
-* A _step_ is a logical concept that represents a single change in a deployment update.  
-  There are three different types of steps, _add_, _remove_, and _modify_. The scope of a step is determined by its most top-level change. For example, if a node is added that also contains a new relationship, this is an 'add node' step, not an 'add relationship' step. Similarly, if a node's property is modified, it is not a 'modify node' step, but a 'modify property' step. A list of all possible steps is located [here]({{< relref "working_with/manager/update-deployment.md#what-can-be-updated-as-a-part-of-a-deployment-update" >}}).
-* After you apply a deployment update, its composite steps are only accessible using the {{< param product_name >}} REST API.
+With {{< param product_name >}}, you can update a deployment, which serves multiple purposes:
+- Changing the deployment topology: for example, adding a new type of database to an existing deployment of webservers and databases.
+- Changing the settings of existing nodes: for example, resizing a volume, or changing the size of a VM instance.
+- Updating the real state of the provisioned resources to match the blueprint. For example: after manually resizing a volume by using a cloud provider's console, run update to bring the volume back to the state described in the blueprint.
 
 ## Describing a Deployment Update
-The contents of the deployment update must be described in a [yaml blueprint file]({{< relref "developer/blueprints/_index.md" >}}), just as any with application in {{< param product_name >}} (note that the blueprint represent the desired state of the deployment after the update). Using the example described in the introduction, the updated application blueprint would include a new database type, some new node templates of the new database type, and some new relationships that represent how these new nodes connect to the existing architecture.
+
+A deployment update consists of:
+- An application blueprint. If a new blueprint is not provided, the current blueprint is used, and the overall deployment topology is kept unchanged.
+- New deployment inputs. If new inputs are not provided, existing inputs are used.
+- Additional parameters for toggling parts of the update flow on and off.
+
+The application blueprint is a [yaml blueprint file]({{<relref "developer/blueprints/_index.md">}}), just as any with any other blueprint in {{< param product_name >}} (note that the blueprint represents the desired state of the deployment after the update). Using the example described in the introduction, the updated application blueprint would include a new database type, some new node templates of the new database type, and some new relationships that represent how these new nodes connect to the existing architecture.
+
+##### Deployment update steps
+
+When an update is executed, the {{< param cfy_manager_name >}} computes the differences between the old blueprint & inputs, and the new blueprint & inputs - based on those differences, the _deployment update steps_ are generated.
+
+A _step_ is a logical concept that represents a single change in a deployment update.
+There are three different types of steps, _add_, _remove_, and _modify_. The scope of a step is determined by its most top-level change. For example, if a node is added that also contains a new relationship, this is an 'add node' step, not an 'add relationship' step. Similarly, if a node's property is modified, it is not a 'modify node' step, but a 'modify property' step. A list of all possible steps is located [here]({{<relref "working_with/manager/update-deployment.md#what-can-be-updated-as-a-part-of-a-deployment-update">}}).
+
+##### Detecting configuration drift
+
+In addition to applying the changes based on a new blueprint, the {{< param cfy_manager_name >}} can also:
+- check the status of each node instance in the deployment
+- if necessary, heal the failing node instances
+- check the configuration drift of each node instance - find the differences between the node configuration as described in the blueprint, and the real state of the provisioned resources
+- if necessary, update the provisioned resources to match the blueprint.
+
+This status and drift checking is based on the operations defined by each node, usually in a plugin.
 
 ## Deployment Update Flow
-Like any other workflow, the built-in `update` workflow must be a part of the deployment update blueprint in order to update a deployment using it. The recommended way of achieving this is to import `types.yaml` (v.3.4, or later) to your blueprint.
 
-Updating a deployment comprises several stages:
+Updating a deployment is a multi-stage process. The high-level overview of the workflow is:
 
+1. The differences between the old and the new blueprint are computed.
 1. The steps composing the deployment update are extracted.
-2. All the 'added' and 'modified' changes are updated in the data model.
-3. The `update` workflow is executed. As a part of the (default) update workflow execution:
-    - The `unlink` operation is executed in regard to each removed relationship.
-    - The `uninstall` workflow is executed on each of the removed nodes.
-    - Old plugins that were outdated are being uninstalled.
-    - The `install` workflow is executed on each of the added nodes.
-    - The `establish` operation is executed in regard to each added relationship.
-    - New plugins that were updated are being installed.
-    - The `reinstall` workflow (uninstall and install) is executed on each of the modified nodes and each of the nodes that were explicitly marked for reinstall.
-4. All 'removed' changes are updated in the data model.
+1. The {{< param cfy_manager_name >}} data storage is updated with:
+    - the updated deployment attributes (e.g. labels)
+    - the newly-created node instances
+    - the updated node properties
+    - the updated node instance relationships
+1. The `uninstall` operations are executed on each deleted node instance.
+1. The `install` operations are executed on each added node instance.
+1. The `check_status` (and `heal` if necessary) operations are executed on all started node instances in the deployment.
+1. The `check_drift` (and `update` if necessary) operations are executed on all started and healthy node instances in the deployment.
+1. The `reinstall` operations are executed on each changed node instance.
+1. The deleted nodes and node-instances are removed from the {{< param cfy_manager_name >}} data storage.
 
-**Workflow/operation execution during a deployment update**<br>
-Stage 3 of the deployment update flow comprises only the cases in which a workflow or an operation is executed during a deployment update. That is, when changing description, removing a workflow, modifying the `install-agent` property or any other step that is not add/remove/modify node or relationship, no workflow or operation is executed. Note that since version 4.4, modifying an existing node (changing its properties and/or operations) will cause automatic reinstallation of this node, unless the flag `--skip-reinstall` has been supplied.
+For a more in-depth description of these steps, see the [workflow documentation]({{<relref "working_with/workflows/built-in-workflows#the-update-workflow">}})
+
+For notes about implementing the `check_drift` and `update` operations, see [implementing drift check]({{<relref "working_with/manager/update-deployment#implementing-drift-check">}})
 
 ## Using {{< param cfy_console_name >}} to Update a Deployment
-To update deployment from the {{< param cfy_console_name >}} go to [Services page]({{< relref 
-"working_with/console/pages/services-page.md" >}}), select deployment from the left pane, then click on the 
+To update a deployment from the {{< param cfy_console_name >}} go to [Services page]({{<relref "working_with/console/pages/services-page.md">}}), select **Deployment** from the left pane, then click on the
 **Deployment Actions** button and select **Update** option.
 
 You will then see Deployment Update modal window:
@@ -66,8 +88,7 @@ In Preview mode you can see the following information:
 
 If you want to get the same information about update performed in the past:
 
- 1. Go to **History** tab on specific deployment page and scroll to [Executions widget]({{< relref 
-    "working_with/console/widgets/executions.md" >}})
+ 1. Go to **History** tab on the specific deployment page and scroll to [Executions widget]({{<relref "working_with/console/widgets/executions.md">}})
 
  2. Click on the menu icon (![List icon]( /images/ui/icons/list-icon.png ) ) on relevant execution and select **Show 
     Update Details** option (only available for executions associated with deployment update)
@@ -98,63 +119,45 @@ The deployment's blueprint and inputs will be updated in the data model.
   cfy deployments history [-d DEPLOYMENT_ID]
   ```
 
-See more of the CLI usage in the [CLI deployments documentation]({{< relref "cli/orch_cli/deployments.md" >}}).
+See more of the CLI usage in the [CLI deployments documentation]({{<relref "cli/orch_cli/deployments.md">}}).
 
-### Automatic and manual reinstall
+## Skipping parts of the update procedure
 
-Nodes that were modified in the update (their properties and/or operations) were changed, will be automatically reinstalled, so the modifications will take affect.
-It is possible to avoid automatic reinstallation of modified nodes, by supplying the flag `--skip-reinstall`.
-It is also possible to manually supply a list of node instances to be reinstalled by using the parameter `--reinstall-list` or `-r`. This parameter can be passed multiple times in a single command, to pass a list of node instances ids. Those node instances that were explicitly supplied will be reinstalled even if the flag `--skip-reinstall` has been supplied (in fact, the flag `--skip-reinstall` is for skipping only the automatic reinstall of modified nodes).
+You can skip parts of the Deployment Update procedure using flags. By default, all phases are enabled. The flags can be combined as needed.
 
-Note: If node's properties that are required for the node's uninstallation has been modified, it is recommended to use the `--skip-reinstall` flag, since the reinstall takes place after the properties has been updated in the data model, and the original properties that could be required for the uninstall may no longer exist. In those cases it is recommended to either split the update into 2 phase that will be performed in 2 different updates (removing the old nodes and then adding the updated ones), or to change the node names in the blueprint, to have them being treated as different nodes.
-It is also recommended to use the `--skip-reinstall` flag in case of a plugin update that may cause reinstallation of all the nodes installed by this plugin, that may not be necessary (especially central deployment plugins, e.g: update of the openstack plugin may trigger automatic reinstallation of all the openstack nodes). It may be wise to update plugins in a separate deployment update dedicated for this action.
-In case of changed properties that are not critical for a successful uninstallation, but can still cause some of the uninstall tasks to fail, the `--ignore-failure` flag can be used, to ignore those irrelevant failures and move on normally (more on that later).
-
-### Skipping the Install/Uninstall/Reinstall Workflow Executions
-
-You can skip the execution of the `install` and/or `uninstall` and/or `reinstall` workflows during the deployment update process.
-
-* If you skip the `install` workflow, added nodes are not installed, added relationships are not established but updated agent-host & central-deployment plugins are installed (unless `update_plugins` is set to `False`).
-* If you skip the `uninstall` workflow, removed nodes are not uninstalled, removed relationships are not unlinked but outdated agent-host & central-deployment plugins are uninstalled (unless `update_plugins` is set to `False`).
-* If you skip the `reinstall` workflow, modified nodes are not reinstalled automatically (nodes that were manually chosen to reinstall will still be reinstalled).
-* If you skip the `update_plugins` workflow, any update plugins (agent-host nor central-deployment) are uninstalled nor installed
-
-* To skip the `install` execution, run the following command:  
+The relevant CLI flags are:
+* To run an update without actually doing any changes to the blueprint, but still run the `check_drift` and `update` operations, use the `--drift-only` flag:
+  ```shell
+  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE --drift-only
+  ```
+* To skip the execution entirely, and exit immediately after generating steps, use the `--preview` flag:
+  ```shell
+  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --preview
+  ```
+* To skip the `install` execution, use the `--skip-install` flag:
   ```shell
   cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --skip-install
   ```
-* To skip the `uninstall` execution, run the following command:  
+  Added nodes will not be installed, added relationships will not be established.
+* To skip the `uninstall` execution, use the `--skip-uninstall` flag:
   ```shell
   cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --skip-uninstall
   ```
-* To skip the automatic `reinstall` execution, run the following command:  
+  Removed nodes will not be uninstalled, removed relationships will not be unlinked.
+* To skip the `reinstall` execution, use the `--skip-reinstall` flag:
   ```shell
   cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --skip-reinstall
   ```
-
-* To skip installing or uninstalling the plugins, use the following command:
+* To skip the `check_status` and `heal` execution, use the `--skip-heal` flag:
   ```shell
-  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --dont-update-plugins
+  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --skip-heal
+  ```
+* To skip the `check_drift` execution, use the `--skip-drift-check` flag:
+  ```shell
+  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --skip-drift-check
   ```
 
-### Manually supplying node instances to reinstall
-
-You can explicitly supply a list of node instance ids to be reinstalled as part of the update. They will be added to the list of modified node instances that need to be reinstalled.
-Even if the flag `--skip-reinstall` was supplied, the nodes that were explicitly passed to the reinstall list will be reinstalled.
-
-* To manually supply node instance ids to reinstall, run the following command (the parameter is passed multiple times as either `--reinstall-list`, or simply `-r`, to form a list of node instances to reinstall):  
-  ```shell
-  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --reinstall-list NODE_INSTANCE_ID_1 -r NODE_INSTANCE_ID_2 -r NODE_INSTANCE_ID_3 --reinstall-list NODE_INSTANCE_ID_4
-  ```
-In this case, when the update will take place all the nodes that were modified and all the nodes that were passed to the list will be reinstalled. If a node instance id is illegal (the node instance either doesn't exist, about to be installed or about to be uninstalled) an error will be thrown and the update will not take place.
-
-* To manually supply node instance ids to reinstall, while avoiding the automatic reinstall, run the following command:  
-  ```shell
-  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --reinstall-list NODE_INSTANCE_ID_1 -r NODE_INSTANCE_ID_2 --skip-reinstall
-  ```
-In this case, only the node instances that were explicitly passed (NODE_INSTANCE_ID_1, NODE_INSTANCE_ID_2) will be reinstalled. The node instances that were modified will not be automatically reinstalled.
-
-### Ignoring failures while uninstalling nodes
+## Ignoring failures while uninstalling nodes
 When running uninstall (including uninstall as part or a reinstall) there are 2 possible ways of handling a recoverable error in a task:
 
 * Like any other workflow, retry the task until it succeeds (and then move on to the next task), or until reached the maximum retries number (and then fail the execution). This is the default behavior.
@@ -172,7 +175,7 @@ This can be used in different situations, for example:
 * The nodes that are being uninstalled have properties that were modified in this update and are being used at the nodes uninstall workflow (but not necessarily critical to its success) and the fact that they were modified may fail some tasks.
 * This update is a roll-back after a failing update, so it is likely that some of its tasks will fail (uninstallation of nodes that were not installed properly in the original update).
 
-### Recovering from a Failed Update
+## Recovering from a Failed Update
 If a deployment update workflow fails during its execution, you would probably want to perform a
 “rollback” in order to recover.  A common solution is to update the deployment with a blueprint
 which represents the previous (state of the) deployment.  In order to do that make sure there is no
@@ -199,31 +202,18 @@ of previous deployment update is aligned with the status of relevant execution.
   cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b ID_OF_THE_ORIGINAL_BLUEPRINT_BEFORE_THE_FIRST_UPDATE --reevaluate-active-statuses --ignore-failure
   ```
 
-### Changing execution order
-By default, the update workflow first uninstalls deleted nodes, then installs added nodes and at last - reinstalls modified nodes.
-The `--install-first` flag can be used to run install before uninstall (not recommended since some resources required for the nodes that are about to be installed may still be taken by the nodes that are about to be uninstalled).
+## Providing Inputs
+You can provide new inputs while updating a deployment. You provide the inputs in the same manner as when [creating a deployment]({{<relref "working_with/manager/create-deployment.md#create-a-deployment">}}), with the following important distinctions:
 
-* To update a deployment with install running before uninstall, run the following command:
-  ```shell
-  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --install-first
-  ```
-
-* To update a deployment with the old behavior, before version 4.4 (install running before uninstall, and reinstall not running at all), run the following command:
-  ```shell
-  cfy deployments update ID_OF_DEPLOYMENT_TO_UPDATE -b BLUEPRINT_ID --install-first --skip-reinstall
-  ```
-
-### Providing Inputs
-You can provide new inputs while updating a deployment. You provide the inputs in the same manner as when [creating a deployment]({{< relref "working_with/manager/create-deployment.md#create-a-deployment" >}}), with the following important distinctions:
-
-* **Overriding inputs**<br>  
+##### Overriding inputs
   If you provide an input with the same name as an existing deployment input, it overrides its value. Other new inputs will be added to the data model as usual.
 
-  _Example: Overriding inputs of existing nodes_<br>
-  Assume that you have the following node in your deployment, and that the `port` input has a value of `8080`:<br>
-  ```
+  _Example: Overriding inputs of existing nodes_
+
+  Assume that you have the following node in your deployment, and that the `port` input has a value of `8080`:
+  ```yaml
     webserver:
-        [...]
+        # ...
         properties:
             port: {get_input: port}
   ```
@@ -232,13 +222,7 @@ You can provide new inputs while updating a deployment. You provide the inputs i
   The overriden input will cause a modification in the `webserver` node (his `port` property was changed). This will trigger an automatic reinstallation of all the instances of the `webserver` node, so the updated port will take affect.
   If the `--skip-reinstall` flag was passed, automatic reinstall will not be triggered, and although the input was overriden to `9090`, the actual port on the existing server will remain `8080`.
 
-* **Referencing Existing Resources and Uploading New Ones**<br>  
-  Since the blueprint has to be uploaded before using it to update the deployment, it has to be a valid blueprint that can be used to create new deployments as well.
-  Therefore, each resources that are being used in this blueprint must be imported or attached to it (cannot rely on resources from the original deployment blueprint).
-  Any resource (scripts, data files, etc.) that will be uploaded with the same name as a resource in the original deployment, will overwrite it.
-  However, entries from the [`imports`]({{< relref "developer/blueprints/spec-imports.md" >}}) section that were part of that deployment's blueprint, or of a previous deployment update, must also be a part of the deployment update blueprint. For example, if the `http://www.getcloudify.org/spec/cloudify/4.4/types.yaml` entry was contained in the imports in the blueprint of the original deployment, the deployment update blueprint must also contain the content of that file. (This is generally achieved by importing the same `types.yaml` file, or a newer version).
-
-### Automatically correcting old inputs' types
+##### Automatically correcting old inputs' types
 In case you are trying to update a deployment but cannot because of an error similar to this one:
 
 ```
@@ -249,6 +233,310 @@ please use the `--auto-correct-types` flag along with `cfy deployments update`. 
 automatically convert old inputs values' types from `string` to `integer`, `float` or `boolean`,
 based on the type of the input declared in a blueprint.
 
+## Implementing drift check
+
+To avoid reinstalling instances when their properties have changed, implement the `check_drift` and `update` operations. Instances of nodes that implement those operations, will run them instead of being reinstalled.
+
+### The `check_drift` operation
+
+The `cloudify.interfaces.lifecycle.check_drift` operation should examine the node properties, the instance runtime properties, and the actual state of the provisioned resource, and compute the differences.
+
+The instance will be considered drifted if this operation returns a non-empty value (for example, a Python dict describing the differences).
+
+The {{< param cfy_manager_name >}} doesn't inspect the returned value, so it can be any object. Plugin authors are advised to return a description of all the differences, so that the `update` operation can act upon them.
+
+{{% note title="Warning" %}}
+If `check_drift` returns an empty or false value, `update` operations will not run, and even in case of blueprint changes (e.g. if the node properties have changed), the instances will not be updated or reinstalled. Take care to always return a non-empty value if there are _any_ changes to the instances.
+{{% /note %}}
+
+If the `check_drift` operation is not implemented, the instances are only considered drifted if there are relevant blueprint changes (e.g. the node properties have changed).
+
+### The `update` operations
+
+The `update` operations are:
+- `cloudify.interfaces.lifecycle.update`
+- `cloudify.interfaces.lifecycle.update_config`
+- `cloudify.interfaces.lifecycle.update_apply`
+
+Plugin authors can implement any, or all, of these operations. These three operations can be implemented in a way that mirrors the `create`, `configure`, and `start` operations.
+
+In these operations, the value returned from `check_drift` can be accessed using `ctx.instance.drift`.
+
+If none of these operations are implemented, the instance will be reinstalled in case of any drift.
+
+### `check_drift` and `update` example
+
+In this example, consider a volume created on some cloud platform - to allow resizing that volume, implement the `check_drift` and `update` operations:
+```yaml
+node_types:
+  type: cloudify.nodes.SomeHypotheticalCloud.Volume
+  properties:
+    size: 100MB
+  interfaces:
+    cloudify.interfaces.lifecycle:
+      check_drift: plugin.some_cloud.volumes.check_drift
+      update: plugin.some_cloud.volumes.update
+```
+
+```python
+def check_drift(ctx):
+    cloud_client = _make_cloud_client(ctx)
+    volume = cloud_client.volumes.get(ctx.instance.id)
+
+    # drift must be a COMPLETE description of drift - including ALL things that
+    # changed. If the result is empty, update will NOT run. In this example,
+    # the only property of the volume is size, so we only check the size.
+    drift = {}
+
+    actual_size = volume.size
+    requested_size = ctx.node.properties['size']
+    if actual_size != requested_size:
+      drift['size'] = {'actual': actual_size, 'requested': requested_size}
+    # if the actual size is equal to requested, return an empty dict - no drift
+    return drift
+
+
+def update(ctx):
+    cloud_client = _make_cloud_client(ctx)
+    volume = cloud_client.volumes.get(ctx.instance.id)
+
+    drift = ctx.instance.drift
+
+    # in this example, if update runs, `size` will always be present, because
+    # that's the only thing that could have changed. In more complex types,
+    # there could be many more changed properties.
+    if 'size' in drift:
+        actual, requested = drift['size']['actual'], drift['size']['requested']
+        ctx.logger.info('Volume size should be %s, but is %s, resizing...',
+                        requested, actual)
+        cloud_client.volumes.resize(volume.id, requested)
+```
+
+## What Can be Updated as a Part of a Deployment Update
+The following can be updated as part of a deployment update, subject to the limitations that were previously described in the [Unsupported Changes]({{<relref "working_with/manager/update-deployment.md#unsupported-changes-in-a-deployment-update">}}) section.
+### Nodes
+You can add or remove nodes, including all their relationships, operations, an so on. Remember that adding or removing a node triggers the install/uninstall workflow in regard to that node.
+{{% note title="'Renaming' Nodes" %}}
+Assume that the original deployment blueprint contains a node named `node1`. Then, in the deployment update blueprint, you decide to 'rename' that node, to `node2`. Now the deployment update blueprint's `node2` is identical to `node1` in the original blueprint, except for its name. But in practice, there isn't really a 'renaming' process. In this scenario, `node1` is uninstalled and `node2` is installed, meaning that `node1` does not retain its state.
+
+```yaml
+# original deployment blueprint
+node_templates:
+    node1:
+        # ...
+```
+```yaml
+# deployment update blueprint
+node_templates:
+    # node1 will be uninstalled. node2 will be installed
+    node2:
+        # ...
+```
+{{% /note %}}
+
+### Relationships
+With the exception of being added or removed as part of adding or removing a node, you can add or remove relationships independently. Adding a relationship triggers an execution of its `establish` operations (assuming a default `install` workflow). Similarly, removing a relationship triggers an execution of the `unlink` operations. You can also change a node's relationship order. The operations of the added and removed relationships are executed according the order of the relationships in the deployment update blueprint.
+```yaml
+# original deployment blueprint
+node_templates:
+    node1:
+        relationships:
+          - type: cloudify.relationships.connected_to
+            target: node2
+```
+```yaml
+# deployment update blueprint
+node_templates:
+    node1:
+        relationships:
+          - type: cloudify.relationships.connected_to
+            target: node3  # the previous relationship to node2 will be removed (unlinked), and a new relationship to node3 will be added (established)
+```
+
+### Operations:
+You can add, remove or modify node operations and relationship operations.
+```yaml
+# original deployment blueprint
+node_templates:
+    node1:
+        interfaces:
+            interface1:
+                operation1:
+                    implementation:
+                        plugin1.path.to.module.taskA
+                operation2:
+                    implementation:
+                        plugin2.path.to.module.taskA
+        relationships:
+          - # ...
+            source_interfaces:
+                interface1:
+                    operation1:
+                        implementation:
+                            plugin1.path.to.module.taskB
+plugins:
+    plugin1:
+        # ...
+    plugin2:
+        # ...
+```
+```yaml
+# deployment update blueprint
+node_templates:
+    node1:
+        interfaces:
+            interface1:
+                operation1:
+                    implementation:  # modified operation1 (changed implementation)
+                        plugin1.path.to.module.taskB
+                # removed operation2
+                operation3:  # added operation 3
+                    implementation:
+                        plugin2.path.to.module.taskB
+        relationships:
+          - # ...
+            source_interfaces:
+                interface1:
+                    operation1:
+                        implementation:  # modified operation1 (changed implementation to a different plugin)
+                            plugin2.path.to.module.taskC
+plugins:
+    plugin1:
+        # ...
+    plugin2:
+        # ...
+```
+
+### Properties
+You can add, remove, or modify properties. Note that overriding a default property value is treated as a property modification.
+```yaml
+# original deployment blueprint
+node_templates:
+    node1:
+        type: Cloudify.nodes.Compute
+    node2:
+        type: my_custom_node_type
+        properties:
+            prop1: value1
+```
+```yaml
+# deployment update blueprint
+node_templates:
+    node1:
+        type: Cloudify.nodes.Compute
+        properties:
+            ip: 192.0.2.1  # modified the property by overriding its default (from types.yaml)
+    node2:
+        type: my_custom_node_type
+        properties:
+            # removed property prop1
+            prop2: value2  # added property prop2
+```
+### Outputs
+You can add, remove or modify outputs.
+```yaml
+# original deployment blueprint
+outputs:
+    output1:
+        value: {get_input: inputA}
+    output2:
+        # ...
+```
+```yaml
+# deployment update blueprint
+outputs:
+    output1:
+        value: {get_input: inputB}  # modified the value of output1
+    # removed output2
+    output3:  # added output3
+        # ...
+```
+### Workflows
+You can add, remove or modify workflows.
+```yaml
+# original deployment blueprint
+workflows:
+    workflow1: plugin_name.module_name.task1
+    workflow2:
+        # ...
+```
+```yaml
+# deployment update blueprint
+outputs:
+    workflow1:
+        value: plugin_name.module_name.task2  # modified the value of workflow1
+    # removed workflow2
+    workflow3:  # added workflow3
+        # ...
+```
+
+### Plugins
+You can add, remove or modify plugins.
+```yaml
+# original deployment blueprint
+imports:
+  - plugin:plugin-name-1?version=1.0
+  - plugin:plugin-name-2?version=1.0
+```
+```yaml
+# deployment update blueprint
+imports:
+  - plugin:plugin-name-1?version=2.0
+  - plugin:plugin-name-3?version=1.0
+```
+In this example, `plugin-name-1` will be updated from version `1.0` to version `2.0`, `plugin-name-3` will be added to the deployment, and `plugin-name-2` removed from it.
+
+In cases of updating a plugin that was used to install nodes in the deployment (for example, Openstack plugin used to install Openstack nodes), the plugin update may trigger automatic reinstallation of those nodes. It can be avoided by using the `--skip-reinstall` flag.
+
+{{% note %}}
+It is possible to import plugins with no version specification at all. Then, the highest version of that plugin will be selected at deployment update time. Therefore, two deployments created (or updated) at different times can use different plugin versions (if a new version of the plugin was uploaded between creating those deployments).
+Also, if the version is not constrained, then any deployment update could lead to unintentionally upgrading the plugin to the newest version.
+{{% /note %}}
+
+If you'd like to update the plugins for all the deployments of some specific blueprint, see [the section below](#updating-plugins-for-a-collection-of-deployments).
+
+If you'd like to learn more about plugins version ranges, [go here](/developer/blueprints/spec-imports/#importing-plugins).
+
+{{% note %}}
+Plugins are installed on first use, so a deployment update is not necessarily going to install them up front. They will only be installed on the machine that attempts to use them, when needed.
+{{% /note %}}
+
+#### Updating plugins for a collection of deployments
+
+If you'd like to perform an update for all the deployment of some blueprint,
+and update only their plugins, you can perform a _plugins update_. You can find
+more information on the CLI command [here](/cli/orch_cli/plugins/#update).
+
+### Description:
+You can add, remove or modify the description.
+
+#### Adding a description:
+```yaml
+# original deployment blueprint
+# no description field
+```
+```yaml
+# deployment update blueprint
+description: new_description  # added description
+```
+#### Removing a description:
+```yaml
+# original deployment blueprint
+description: description_content
+```
+```yaml
+# deployment update blueprint
+# removed the description
+```
+#### Modifying a description:
+```yaml
+# original deployment blueprint
+description: old_description
+```
+```yaml
+# deployment update blueprint
+description: new_description
+```
 
 ## Unsupported Changes in a Deployment Update
 If a deployment update blueprint contains changes that are not currently supported as a part of an update, the update is not executed, and a message indicating the unsupported changes will be displayed to the user. Following is a list of unsupported changes, together with some possible examples.
@@ -291,7 +579,7 @@ You cannot change a relationship's property, for example, `connection_type`.
 node_templates:
     node1:
         relationships:
-          - [...]
+          - # ...
             properties:
                 connection_type: all_to_all
 ```
@@ -300,247 +588,9 @@ node_templates:
 node_templates:
     node1:
         relationships:
-          - [...]
+          - # ...
             properties:
                 connection_type: all_to_one  # unsupported update - can't modify a relationship's property
 ```
 ### Groups, Policy Types and Policy Triggers
 You cannot make changes in the top level fields `groups`, `policy_types` and `policy_triggers` as a part of a deployment update blueprint.
-
-## What Can be Updated as a Part of a Deployment Update
-The following can be updated as part of a deployment update, subject to the limitations that were previously described in the [Unsupported Changes]({{< relref "working_with/manager/update-deployment.md#unsupported-changes-in-a-deployment-update" >}}) section.
-### Nodes
-You can add or remove nodes, including all their relationships, operations, an so on. Remember that adding or removing a node triggers the install/uninstall workflow in regard to that node.
-{{% note title="'Renaming' Nodes" %}}
-Assume that the original deployment blueprint contains a node named `node1`. Then, in the deployment update blueprint, you decide to 'rename' that node, to `node2`. Now the deployment update blueprint's `node2` is identical to `node1` in the original blueprint, except for its name. But in practice, there isn't really a 'renaming' process. In this scenario, `node1` is uninstalled and `node2` is installed, meaning that `node1` does not retain its state.
-
-```yaml
-# original deployment blueprint
-node_templates:
-    node1:
-        [...]
-```
-```yaml
-# deployment update blueprint
-node_templates:
-    node2:  # node1 will be uninstalled. node2 will be installed
-        [...]
-```
-{{% /note %}}
-
-### Relationships
-With the exception of being added or removed as part of adding or removing a node, you can add or remove relationships independently. Adding a relationship triggers an execution of its `establish` operations (assuming a default `install` workflow). Similarly, removing a relationship triggers an execution of the `unlink` operations. You can also change a node's relationship order. The operations of the added and removed relationships are executed according the order of the relationships in the deployment update blueprint.
-```yaml
-# original deployment blueprint
-node_templates:
-    node1:
-        relationships:
-          - type: cloudify.relationships.connected_to
-            target: node2
-```
-```yaml
-# deployment update blueprint
-node_templates:
-    node1:
-        relationships:
-          - type: cloudify.relationships.connected_to
-            target: node3  # the previous relationship to node2 will be removed (unlinked), and a new relationship to node3 will be added (established)
-```
-
-### Operations:
-You can add, remove or modify node operations and relationship operations.
-```yaml
-# original deployment blueprint
-node_templates:
-    node1:
-        interfaces:
-            interface1:
-                operation1:
-                    implementation:
-                        plugin1.path.to.module.taskA
-                operation2:
-                    implementation:
-                        plugin2.path.to.module.taskA
-        relationships:
-          - [...]
-            source_interfaces:
-                interface1:
-                    operation1:
-                        implementation:
-                            plugin1.path.to.module.taskB
-plugins:
-    plugin1:
-        [...]
-    plugin2:
-        [...]
-```
-```yaml
-# deployment update blueprint
-node_templates:
-    node1:
-        interfaces:
-            interface1:
-                operation1:
-                    implementation:  # modified operation1 (changed implementation)
-                        plugin1.path.to.module.taskB
-                # removed operation2
-                operation3:  # added operation 3
-                    implementation:
-                        plugin2.path.to.module.taskB
-        relationships:
-          - [...]
-            source_interfaces:
-                interface1:
-                    operation1:
-                        implementation:  # modified operation1 (changed implementation to a different plugin)
-                            plugin2.path.to.module.taskC
-plugins:
-    plugin1:
-        [...]
-    plugin2:
-        [...]
-```
-
-### Properties
-You can add, remove, or modify properties. Note that overriding a default property value is treated as a property modification.
-```yaml
-# original deployment blueprint
-node_templates:
-    node1:
-        type: Cloudify.nodes.Compute
-    node2:
-        type: my_custom_node_type
-        properties:
-            prop1: value1
-```
-```yaml
-# deployment update blueprint
-node_templates:
-    node1:
-        type: Cloudify.nodes.Compute
-        properties:
-            ip: 192.0.2.1  # modified the property by overriding its default (from types.yaml)
-    node2:
-        type: my_custom_node_type
-        properties:
-            # removed property prop1
-            prop2: value2  # added property prop2
-```
-### Outputs
-You can add, remove or modify outputs.
-```yaml
-# original deployment blueprint
-outputs:
-    output1:
-        value: {get_input: inputA}
-    output2:
-        [...]
-```
-```yaml
-# deployment update blueprint
-outputs:
-    output1:
-        value: {get_input: inputB}  # modified the value of output1
-    # removed output2
-    output3:  # added output3
-        [...]
-```
-### Workflows
-You can add, remove or modify workflows.
-```yaml
-# original deployment blueprint
-workflows:
-    workflow1: plugin_name.module_name.task1
-    workflow2:
-        [...]
-```
-```yaml
-# deployment update blueprint
-outputs:
-    workflow1:
-        value: plugin_name.module_name.task2  # modified the value of workflow1
-    # removed workflow2
-    workflow3:  # added workflow3
-        [...]
-```
-
-### Plugins
-You can add, remove or modify plugins.
-```yaml
-# original deployment blueprint
-imports:
-  - plugin:plugin-name-1?version=1.0
-  - plugin:plugin-name-2?version=1.0
-```
-```yaml
-# deployment update blueprint
-imports:
-  - plugin:plugin-name-1?version=2.0
-  - plugin:plugin-name-3?version=1.0
-```
-In this example, `plugin-name-1` will be updated from version `1.0` to version `2.0`, `plugin-name-3` will be added to the deployment, and `plugin-name-2` removed from it.
-
-In cases of updating a plugin that was used to install nodes in the deployment (for example, Openstack plugin used to install Openstack nodes), the plugin update may trigger automatic reinstallation of those nodes. It can be avoided by using the `--skip-reinstall` flag.
-
-Note: it is possible to import plugins stating some version range or no version specifications at all. In this case, the plugin that will be used will be the one with the newest version within that range and a matching name and distribution.
-In the case where no version specifications has been used, the newest plugin version will be used with a matching name and distribution.
-The plugin is being associated with the blueprint when the blueprint is uploaded, so it is possible that the same blueprint that was uploaded twice will be associated each time with a different plugin version.
-When updating a deployment with a specific blueprint, the plugins that will be used in the deployment after the update are those associated with the blueprint.
-Update a plugin's version in a specific deployment can be done by uploading the same blueprint again without any changes, assuming a newer plugin is available. This version update can also happen unintentionally and needs to be considered.
-
-If you'd like to update the plugins for all the deployments of some specific blueprint, see [the section below](#updating-plugins-for-a-collection-of-deployments).
-
-If you'd like to learn more about plugins version ranges, [go here](/developer/blueprints/spec-imports/#importing-plugins).
-
-#### Updating plugins for a collection of deployments
-
-If you'd like to perform an update for all the deployment of some blueprint,
-and update only their plugins, you can perform a _plugins update_. You can find
-more information on the CLI command [here](/cli/orch_cli/plugins/#update).
-
-### Description:
-You can add, remove or modify the description.
-
-#### Adding a description:
-```yaml
-# original deployment blueprint
-# no description field
-```
-```yaml
-# deployment update blueprint
-description: new_description  # added description
-```
-#### Removing a description:
-```yaml
-# original deployment blueprint
-description: description_content
-```
-```yaml
-# deployment update blueprint
-# removed the description
-```
-#### Modifying a description:
-```yaml
-# original deployment blueprint
-description: old_description
-```
-```yaml
-# deployment update blueprint
-description: new_description
-```
-
-## Known Issues
-### Policy types - Unsupported Changes
-When using a `types.yaml` file of version 3.3.1 or older, you might encounter the following error while trying to update your deployment, even if your [policy types](http://docs.getcloudify.org/3.4.0/blueprints/spec-policy-types/) are identical between the original and deployment update blueprints:
-```
-The blueprint you provided for the deployment update contains changes currently unsupported by the deployment update mechanism.
-Unsupported Changes:
-```
-followed by one or two of the following lines:
-```
-policy_types:cloudify.policies.types.ewma_stabilized
-policy_types:cloudify.policies.types.threshold
-```
-This problem originates from a DSL issue, and will be resolved in versions 3.4.1 and above.
-
-To mitigate this problems, use a `types.yaml` of version 3.4 and above, or at least use the `policy_types` section of it.


### PR DESCRIPTION
* Remove a note about a 3.4-related issue

* Update the document into to talk about drift/status

* remove the types.yaml comment

it's not true anymore, update is a built-in workflow

* Describe the flow

* Update the notes about skipping parts of the workflow

* remove pointless "existing resources" paragraph

yes the blueprint must already exist, and the things that changed in it, have changed

* Describe implementing check_drift & update

* move "unsupported" to after "supported"

* update the note on plugins

Plugins are installed on first use!

* add a note about --drift-only

* markdown syntax updates

Now no warnings in my editor :)

* s/eg./e.g./

That is the way to write it indeed

Co-authored-by: glukhman <47591609+glukhman@users.noreply.github.com>

* Add a few "the"

Co-authored-by: glukhman <47591609+glukhman@users.noreply.github.com>

* add an example of check_drift & update

* s/those/these/

thanks @geokala

Co-authored-by: glukhman <47591609+glukhman@users.noreply.github.com>